### PR TITLE
fix(pxar): fix inaccurate restore job summary counters

### DIFF
--- a/internal/pxar/format.go
+++ b/internal/pxar/format.go
@@ -257,6 +257,11 @@ func (r *PxarReader) LookupByPath(ctx context.Context, path string) (*EntryInfo,
 	}
 
 	r.cacheEntry(entry)
+	if entry.IsDir() {
+		r.FolderCount.Add(1)
+	} else {
+		r.FileCount.Add(1)
+	}
 	return entryToEntryInfo(entry), nil
 }
 
@@ -310,6 +315,11 @@ func (r *PxarReader) GetAttr(ctx context.Context, entryStart, entryEnd uint64) (
 		return nil, fmt.Errorf("entry at offset %d: %w", entryStart, err)
 	}
 	r.cacheEntry(entry)
+	if entry.IsDir() {
+		r.FolderCount.Add(1)
+	} else {
+		r.FileCount.Add(1)
+	}
 	return entryToEntryInfo(entry), nil
 }
 
@@ -349,6 +359,7 @@ func (r *PxarReader) ReadFileContentReader(ctx context.Context, contentStart, co
 	if targetEntry == nil {
 		return nil, fmt.Errorf("entry with content offset %d not found in cache", contentStart)
 	}
+	r.TotalBytes.Add(int64(targetEntry.FileSize))
 	return r.reader.ReadFileContentReader(targetEntry)
 }
 


### PR DESCRIPTION
## Problem

Restore job summaries show 0 files, 0 folders, and 0 B even when restores succeed.

## Root cause

`LookupByPath` and `GetAttr` (cache miss) were not incrementing `FileCount`/`FolderCount`. `ReadFileContentReader` was not incrementing `TotalBytes` (only the remote fallback `Read()` path did).

## Fix

- Increment `FileCount`/`FolderCount` in `LookupByPath`  
- Increment `FileCount`/`FolderCount` on `GetAttr` cache miss
- Increment `TotalBytes` by `FileSize` in `ReadFileContentReader` (the `Read()` fallback path already tracked bytes)