### PR TITLE
feat(restore): optimize memory usage with configurable payload cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.100
 	github.com/mxk/go-vss v1.2.1
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/pbs-plus/pxar v0.16.6
+	github.com/pbs-plus/pxar v0.16.7
 	github.com/prometheus/client_golang v1.23.2
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/quic-go/quic-go v0.59.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.100
 	github.com/mxk/go-vss v1.2.1
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
-	github.com/pbs-plus/pxar v0.16.5
+	github.com/pbs-plus/pxar v0.16.6
 	github.com/prometheus/client_golang v1.23.2
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
 	github.com/quic-go/quic-go v0.59.0

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
-github.com/pbs-plus/pxar v0.16.5 h1:5IopMc7pNNm2JiXVqWSqf7VLli0DgVd7uRNQ1npg0pQ=
-github.com/pbs-plus/pxar v0.16.5/go.mod h1:yt3dqfE6UkDZuaJgi4Aoe9i2u5Ok8x8LQJgjhUFiqvQ=
-github.com/pbs-plus/pxar v0.16.6 h1:Eeqq4gg/VvZv1njLgxkQ2uF39i0I4rR0AV3lbAz6nls=
-github.com/pbs-plus/pxar v0.16.6/go.mod h1:yt3dqfE6UkDZuaJgi4Aoe9i2u5Ok8x8LQJgjhUFiqvQ=
+github.com/pbs-plus/pxar v0.16.7 h1:fto4BNwcwxcZjWZjJkWWsp+KwjumDX8JagIlMefWPmQ=
+github.com/pbs-plus/pxar v0.16.7/go.mod h1:yt3dqfE6UkDZuaJgi4Aoe9i2u5Ok8x8LQJgjhUFiqvQ=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2D
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pbs-plus/pxar v0.16.5 h1:5IopMc7pNNm2JiXVqWSqf7VLli0DgVd7uRNQ1npg0pQ=
 github.com/pbs-plus/pxar v0.16.5/go.mod h1:yt3dqfE6UkDZuaJgi4Aoe9i2u5Ok8x8LQJgjhUFiqvQ=
+github.com/pbs-plus/pxar v0.16.6 h1:Eeqq4gg/VvZv1njLgxkQ2uF39i0I4rR0AV3lbAz6nls=
+github.com/pbs-plus/pxar v0.16.6/go.mod h1:yt3dqfE6UkDZuaJgi4Aoe9i2u5Ok8x8LQJgjhUFiqvQ=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/pxar/format.go
+++ b/internal/pxar/format.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pbs-plus/pbs-plus/internal/server/proxmox"
@@ -49,7 +50,7 @@ type PxarReader struct {
 	TotalBytes  *xsync.Counter
 
 	task   TaskWriter
-	closed bool
+	closed atomic.Bool
 }
 
 // PxarReaderStats holds read performance statistics.
@@ -173,14 +174,22 @@ func NewPxarReader(_ context.Context, _, pbsStore, namespace, snapshot string, t
 
 // Close releases all resources held by the reader.
 func (r *PxarReader) Close() error {
-	if r.closed {
+	if !r.closed.CompareAndSwap(false, true) {
 		return nil
 	}
-	r.closed = true
 	if r.reader != nil {
 		return r.reader.Close()
 	}
 	return nil
+}
+
+// DisablePayloadCache disables chunk caching for the payload stream.
+// Content chunks are decoded on demand and immediately discarded,
+// keeping memory bounded during streaming restores.
+func (r *PxarReader) DisablePayloadCache() {
+	if r.reader != nil {
+		r.reader.DisablePayloadCache()
+	}
 }
 
 // cacheEntry stores an entry in the lookup cache.

--- a/internal/pxar/format.go
+++ b/internal/pxar/format.go
@@ -183,12 +183,11 @@ func (r *PxarReader) Close() error {
 	return nil
 }
 
-// DisablePayloadCache disables chunk caching for the payload stream.
-// Content chunks are decoded on demand and immediately discarded,
-// keeping memory bounded during streaming restores.
-func (r *PxarReader) DisablePayloadCache() {
+// SetPayloadCacheSize adjusts the payload chunk cache size.
+// n=0 disables caching entirely (lowest memory), n>0 caps the cache.
+func (r *PxarReader) SetPayloadCacheSize(n int) {
 	if r.reader != nil {
-		r.reader.DisablePayloadCache()
+		r.reader.SetPayloadCacheSize(n)
 	}
 }
 

--- a/internal/pxar/restore.go
+++ b/internal/pxar/restore.go
@@ -19,6 +19,15 @@ const (
 	RestoreModeNoAttr
 )
 
+// copyBufPool reuses 256KB buffers across sequential restoreFile calls,
+// avoiding per-file heap allocations.
+var copyBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 256*1024)
+		return &buf
+	},
+}
+
 type RestoreOptions struct {
 	Mode    RestoreMode
 	DestDir string
@@ -162,9 +171,9 @@ func restoreFile(ctx context.Context, client *Client, path string, e EntryInfo, 
 			} else {
 				defer rc.Close()
 
-				const bufSize = 256 * 1024
-				buf := make([]byte, bufSize)
-				if _, err := io.CopyBuffer(f, rc, buf); err != nil {
+				bufPtr := copyBufPool.Get().(*[]byte)
+				defer copyBufPool.Put(bufPtr)
+				if _, err := io.CopyBuffer(f, rc, *bufPtr); err != nil {
 					return fmt.Errorf("copy data %q: %w", path, err)
 				}
 			}

--- a/internal/server/database/migrations/000023_add_payload_cache_chunks.down.sql
+++ b/internal/server/database/migrations/000023_add_payload_cache_chunks.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE restores DROP COLUMN payload_cache_chunks;

--- a/internal/server/database/migrations/000023_add_payload_cache_chunks.up.sql
+++ b/internal/server/database/migrations/000023_add_payload_cache_chunks.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE restores ADD COLUMN payload_cache_chunks INTEGER NOT NULL DEFAULT 0;

--- a/internal/server/database/queries/restores.sql
+++ b/internal/server/database/queries/restores.sql
@@ -2,15 +2,16 @@
 INSERT INTO restores (
     id, store, namespace, snapshot, src_path, dest_target, dest_subpath,
     comment, current_pid, last_run_upid, last_successful_upid, retry,
-    retry_interval, pre_script, post_script, restore_mode, last_run_status, retry_count
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    retry_interval, pre_script, post_script, restore_mode, last_run_status, retry_count,
+    payload_cache_chunks
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetRestore :one
 SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count,
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks,
     t.name, t.path, t.agent_host, t.volume_id, t.volume_type, t.volume_name,
     t.volume_fs, t.volume_total_bytes, t.volume_used_bytes, t.volume_free_bytes,
     t.volume_total, t.volume_used, t.volume_free, t.mount_script,
@@ -27,7 +28,7 @@ SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count,
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks,
     t.name, t.path, t.agent_host, t.volume_id, t.volume_type, t.volume_name,
     t.volume_fs, t.volume_total_bytes, t.volume_used_bytes, t.volume_free_bytes,
     t.volume_total, t.volume_used, t.volume_free, t.mount_script,
@@ -43,7 +44,7 @@ SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks
 FROM restores j
 LEFT JOIN targets t ON j.dest_target = t.name
 WHERE j.last_run_upid LIKE '%pbsplusgen-queue%'
@@ -54,7 +55,8 @@ UPDATE restores
 SET store = ?, namespace = ?, snapshot = ?, src_path = ?, dest_target = ?,
     dest_subpath = ?, comment = ?, current_pid = ?, last_run_upid = ?,
     retry = ?, retry_interval = ?, last_successful_upid = ?,
-    pre_script = ?, post_script = ?, restore_mode = ?, last_run_status = ?, retry_count = ?
+    pre_script = ?, post_script = ?, restore_mode = ?, last_run_status = ?, retry_count = ?,
+    payload_cache_chunks = ?
 WHERE id = ?;
 
 -- name: DeleteRestore :execrows

--- a/internal/server/database/restores.go
+++ b/internal/server/database/restores.go
@@ -130,6 +130,7 @@ func (database *Database) CreateRestore(tx *Transaction, restore Restore) (err e
 		RestoreMode:        int64(restore.Mode),
 		LastRunStatus:      toNullInt64(int(restore.History.LastRunStatus)),
 		RetryCount:         toNullInt64(restore.History.RetryCount),
+		PayloadCacheChunks: int64(restore.PayloadCacheChunks),
 	})
 	if err != nil {
 		return fmt.Errorf("CreateRestore: error inserting restore: %w", err)
@@ -184,11 +185,12 @@ func (database *Database) GetRestore(id string) (Restore, error) {
 			LastRunStatus:      JobStatus(fromNullInt64(row.LastRunStatus)),
 			RetryCount:         fromNullInt64(row.RetryCount),
 		},
-		Retry:         fromNullInt64(row.Retry),
-		RetryInterval: fromNullInt64(row.RetryInterval),
-		Mode:          int(row.RestoreMode),
-		PreScript:     row.PreScript,
-		PostScript:    row.PostScript,
+		Retry:              fromNullInt64(row.Retry),
+		RetryInterval:      fromNullInt64(row.RetryInterval),
+		Mode:               int(row.RestoreMode),
+		PayloadCacheChunks: int(row.PayloadCacheChunks),
+		PreScript:          row.PreScript,
+		PostScript:         row.PostScript,
 	}
 
 	restore.DestTarget.populateInfo()
@@ -288,6 +290,7 @@ func (database *Database) UpdateRestore(tx *Transaction, restore Restore) (err e
 		Snapshot:           restore.Snapshot,
 		SrcPath:            restore.SrcPath,
 		RestoreMode:        int64(restore.Mode),
+		PayloadCacheChunks: int64(restore.PayloadCacheChunks),
 		DestTarget:         restore.DestTarget.Name,
 		DestSubpath:        toNullString(restore.DestSubpath),
 		Comment:            toNullString(restore.Comment),
@@ -437,7 +440,8 @@ func (database *Database) GetAllQueuedRestores() ([]Restore, error) {
 			Store:    row.Store,
 			Snapshot: row.Snapshot,
 			SrcPath:  row.SrcPath,
-			Mode:     int(row.RestoreMode),
+			Mode:               int(row.RestoreMode),
+			PayloadCacheChunks: int(row.PayloadCacheChunks),
 			DestTarget: Target{
 				Name:      row.DestTarget,
 				AgentHost: AgentHost{},

--- a/internal/server/database/sqlc/models.go
+++ b/internal/server/database/sqlc/models.go
@@ -68,6 +68,7 @@ type Restore struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 }
 
 type Script struct {

--- a/internal/server/database/sqlc/restores.sql.go
+++ b/internal/server/database/sqlc/restores.sql.go
@@ -25,8 +25,9 @@ const createRestore = `-- name: CreateRestore :exec
 INSERT INTO restores (
     id, store, namespace, snapshot, src_path, dest_target, dest_subpath,
     comment, current_pid, last_run_upid, last_successful_upid, retry,
-    retry_interval, pre_script, post_script, restore_mode, last_run_status, retry_count
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    retry_interval, pre_script, post_script, restore_mode, last_run_status, retry_count,
+    payload_cache_chunks
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateRestoreParams struct {
@@ -48,6 +49,7 @@ type CreateRestoreParams struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 }
 
 func (q *Queries) CreateRestore(ctx context.Context, arg CreateRestoreParams) error {
@@ -70,6 +72,7 @@ func (q *Queries) CreateRestore(ctx context.Context, arg CreateRestoreParams) er
 		arg.RestoreMode,
 		arg.LastRunStatus,
 		arg.RetryCount,
+		arg.PayloadCacheChunks,
 	)
 	return err
 }
@@ -91,7 +94,7 @@ SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count,
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks,
     t.name, t.path, t.agent_host, t.volume_id, t.volume_type, t.volume_name,
     t.volume_fs, t.volume_total_bytes, t.volume_used_bytes, t.volume_free_bytes,
     t.volume_total, t.volume_used, t.volume_free, t.mount_script,
@@ -123,6 +126,7 @@ type GetRestoreRow struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 	Name               sql.NullString `json:"name"`
 	Path               sql.NullString `json:"path"`
 	AgentHost          sql.NullString `json:"agent_host"`
@@ -166,6 +170,7 @@ func (q *Queries) GetRestore(ctx context.Context, id string) (GetRestoreRow, err
 		&i.RestoreMode,
 		&i.LastRunStatus,
 		&i.RetryCount,
+		&i.PayloadCacheChunks,
 		&i.Name,
 		&i.Path,
 		&i.AgentHost,
@@ -194,7 +199,7 @@ SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count,
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks,
     t.name, t.path, t.agent_host, t.volume_id, t.volume_type, t.volume_name,
     t.volume_fs, t.volume_total_bytes, t.volume_used_bytes, t.volume_free_bytes,
     t.volume_total, t.volume_used, t.volume_free, t.mount_script,
@@ -225,6 +230,7 @@ type ListAllRestoresRow struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 	Name               sql.NullString `json:"name"`
 	Path               sql.NullString `json:"path"`
 	AgentHost          sql.NullString `json:"agent_host"`
@@ -274,6 +280,7 @@ func (q *Queries) ListAllRestores(ctx context.Context) ([]ListAllRestoresRow, er
 			&i.RestoreMode,
 			&i.LastRunStatus,
 			&i.RetryCount,
+			&i.PayloadCacheChunks,
 			&i.Name,
 			&i.Path,
 			&i.AgentHost,
@@ -312,7 +319,7 @@ SELECT
     j.id, j.store, j.namespace, j.snapshot, j.src_path, j.dest_target,
     j.dest_subpath, j.comment, j.current_pid, j.last_run_upid,
     j.last_successful_upid, j.retry, j.retry_interval, j.pre_script, j.post_script,
-    j.restore_mode, j.last_run_status, j.retry_count
+    j.restore_mode, j.last_run_status, j.retry_count, j.payload_cache_chunks
 FROM restores j
 LEFT JOIN targets t ON j.dest_target = t.name
 WHERE j.last_run_upid LIKE '%pbsplusgen-queue%'
@@ -338,6 +345,7 @@ type ListQueuedRestoresRow struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 }
 
 func (q *Queries) ListQueuedRestores(ctx context.Context) ([]ListQueuedRestoresRow, error) {
@@ -368,6 +376,7 @@ func (q *Queries) ListQueuedRestores(ctx context.Context) ([]ListQueuedRestoresR
 			&i.RestoreMode,
 			&i.LastRunStatus,
 			&i.RetryCount,
+			&i.PayloadCacheChunks,
 		); err != nil {
 			return nil, err
 		}
@@ -398,7 +407,8 @@ UPDATE restores
 SET store = ?, namespace = ?, snapshot = ?, src_path = ?, dest_target = ?,
     dest_subpath = ?, comment = ?, current_pid = ?, last_run_upid = ?,
     retry = ?, retry_interval = ?, last_successful_upid = ?,
-    pre_script = ?, post_script = ?, restore_mode = ?, last_run_status = ?, retry_count = ?
+    pre_script = ?, post_script = ?, restore_mode = ?, last_run_status = ?, retry_count = ?,
+    payload_cache_chunks = ?
 WHERE id = ?
 `
 
@@ -420,6 +430,7 @@ type UpdateRestoreParams struct {
 	RestoreMode        int64          `json:"restore_mode"`
 	LastRunStatus      sql.NullInt64  `json:"last_run_status"`
 	RetryCount         sql.NullInt64  `json:"retry_count"`
+	PayloadCacheChunks int64          `json:"payload_cache_chunks"`
 	ID                 string         `json:"id"`
 }
 
@@ -442,6 +453,7 @@ func (q *Queries) UpdateRestore(ctx context.Context, arg UpdateRestoreParams) er
 		arg.RestoreMode,
 		arg.LastRunStatus,
 		arg.RetryCount,
+		arg.PayloadCacheChunks,
 		arg.ID,
 	)
 	return err

--- a/internal/server/database/types.go
+++ b/internal/server/database/types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
 )
 
 // JobStatus is a typed enum for job completion status.
@@ -145,24 +144,25 @@ type Exclusion struct {
 }
 
 type Restore struct {
-	ID            string     `json:"id"`
-	Store         string     `json:"store"`
-	Snapshot      string     `json:"snapshot"`
-	Namespace     string     `json:"ns"`
-	Mode          int        `json:"mode"`
-	SrcPath       string     `json:"src-path"`
-	DestTarget    Target     `json:"dest-target"`
-	DestSubpath   string     `json:"dest-subpath"`
-	PreScript     string     `json:"pre_script"`
-	PostScript    string     `json:"post_script"`
-	Comment       string     `json:"comment"`
-	Retry         int        `json:"retry"`
-	RetryInterval int        `json:"retry-interval"`
-	CurrentPID    int        `json:"current_pid"`
-	ExpectedSize  int        `json:"expected_size,omitempty"`
-	UPIDs         []string   `json:"upids"`
-	CurrentStats  JobStats   `json:"current-stats"`
-	History       JobHistory `json:"history"`
+	ID                 string     `json:"id"`
+	Store              string     `json:"store"`
+	Snapshot           string     `json:"snapshot"`
+	Namespace          string     `json:"ns"`
+	Mode               int        `json:"mode"`
+	PayloadCacheChunks int        `json:"payload-cache-chunks"`
+	SrcPath            string     `json:"src-path"`
+	DestTarget         Target     `json:"dest-target"`
+	DestSubpath        string     `json:"dest-subpath"`
+	PreScript          string     `json:"pre_script"`
+	PostScript         string     `json:"post_script"`
+	Comment            string     `json:"comment"`
+	Retry              int        `json:"retry"`
+	RetryInterval      int        `json:"retry-interval"`
+	CurrentPID         int        `json:"current_pid"`
+	ExpectedSize       int        `json:"expected_size,omitempty"`
+	UPIDs              []string   `json:"upids"`
+	CurrentStats       JobStats   `json:"current-stats"`
+	History            JobHistory `json:"history"`
 }
 
 type Script struct {
@@ -196,25 +196,25 @@ type JobHistory struct {
 }
 
 type Target struct {
-	Name             string       `json:"name"`
-	Type             TargetType   `json:"target_type"`
-	Path             string       `json:"path"`
-	AgentHost        AgentHost    `json:"agent_host"`
-	VolumeID         string       `json:"volume_id,omitempty"`
-	MountScript      string       `json:"mount_script"`
-	AgentVersion     string       `json:"agent_version"`
-	ConnectionStatus bool         `json:"connection_status"`
-	JobCount         int          `json:"job_count"`
-	VolumeType       string       `json:"volume_type"`
-	VolumeName       string       `json:"volume_name"`
-	VolumeFS         string       `json:"volume_fs"`
-	VolumeTotalBytes int          `json:"volume_total_bytes,omitempty"`
-	VolumeUsedBytes  int          `json:"volume_used_bytes,omitempty"`
-	VolumeFreeBytes  int          `json:"volume_free_bytes,omitempty"`
-	VolumeTotal      string       `json:"volume_total"`
-	VolumeUsed       string       `json:"volume_used"`
-	VolumeFree       string       `json:"volume_free"`
-	S3Info           *S3Url `json:"s3_info"`
+	Name             string     `json:"name"`
+	Type             TargetType `json:"target_type"`
+	Path             string     `json:"path"`
+	AgentHost        AgentHost  `json:"agent_host"`
+	VolumeID         string     `json:"volume_id,omitempty"`
+	MountScript      string     `json:"mount_script"`
+	AgentVersion     string     `json:"agent_version"`
+	ConnectionStatus bool       `json:"connection_status"`
+	JobCount         int        `json:"job_count"`
+	VolumeType       string     `json:"volume_type"`
+	VolumeName       string     `json:"volume_name"`
+	VolumeFS         string     `json:"volume_fs"`
+	VolumeTotalBytes int        `json:"volume_total_bytes,omitempty"`
+	VolumeUsedBytes  int        `json:"volume_used_bytes,omitempty"`
+	VolumeFreeBytes  int        `json:"volume_free_bytes,omitempty"`
+	VolumeTotal      string     `json:"volume_total"`
+	VolumeUsed       string     `json:"volume_used"`
+	VolumeFree       string     `json:"volume_free"`
+	S3Info           *S3Url     `json:"s3_info"`
 }
 
 type AgentHost struct {

--- a/internal/server/restore/job.go
+++ b/internal/server/restore/job.go
@@ -48,7 +48,7 @@ type restoreJob struct {
 	storeInstance       *store.Store
 	skipCheck           bool
 	web                 bool
-	disablePayloadCache bool
+	payloadCacheChunks int
 }
 
 // NewRestoreJob creates a new restore job.
@@ -71,7 +71,7 @@ func NewRestoreJob(
 		waitGroup:           &sync.WaitGroup{},
 		task:                task,
 		disconnected:        make(chan struct{}, 1),
-		disablePayloadCache: true,
+		payloadCacheChunks: job.PayloadCacheChunks,
 	}
 
 	return &jobs.Job{
@@ -362,8 +362,8 @@ func (b *restoreJob) agentExecute(ctx context.Context) error {
 		return err
 	}
 
-	if b.disablePayloadCache {
-		reader.DisablePayloadCache()
+	if b.payloadCacheChunks >= 0 {
+		reader.SetPayloadCacheSize(b.payloadCacheChunks)
 	}
 
 	b.task.WriteString(fmt.Sprintf(
@@ -440,8 +440,8 @@ func (b *restoreJob) localExecute(ctx context.Context) error {
 		return err
 	}
 
-	if b.disablePayloadCache {
-		reader.DisablePayloadCache()
+	if b.payloadCacheChunks >= 0 {
+		reader.SetPayloadCacheSize(b.payloadCacheChunks)
 	}
 
 	b.localClient, b.errCh = pxar.NewLocalClient(reader, b.job.ID)

--- a/internal/server/restore/job.go
+++ b/internal/server/restore/job.go
@@ -42,12 +42,13 @@ type restoreJob struct {
 	receivedDone atomic.Bool
 	disconnected chan struct{}
 
-	job           database.Restore
-	remoteServer  *pxar.RemoteServer
-	localClient   *pxar.Client
-	storeInstance *store.Store
-	skipCheck     bool
-	web           bool
+	job                 database.Restore
+	remoteServer        *pxar.RemoteServer
+	localClient         *pxar.Client
+	storeInstance       *store.Store
+	skipCheck           bool
+	web                 bool
+	disablePayloadCache bool
 }
 
 // NewRestoreJob creates a new restore job.
@@ -63,13 +64,14 @@ func NewRestoreJob(
 	}
 
 	j := &restoreJob{
-		job:           job,
-		storeInstance: storeInstance,
-		skipCheck:     skipCheck,
-		web:           web,
-		waitGroup:     &sync.WaitGroup{},
-		task:          task,
-		disconnected:  make(chan struct{}, 1),
+		job:                 job,
+		storeInstance:       storeInstance,
+		skipCheck:           skipCheck,
+		web:                 web,
+		waitGroup:           &sync.WaitGroup{},
+		task:                task,
+		disconnected:        make(chan struct{}, 1),
+		disablePayloadCache: true,
 	}
 
 	return &jobs.Job{
@@ -360,6 +362,10 @@ func (b *restoreJob) agentExecute(ctx context.Context) error {
 		return err
 	}
 
+	if b.disablePayloadCache {
+		reader.DisablePayloadCache()
+	}
+
 	b.task.WriteString(fmt.Sprintf(
 		"running remote pxar reader [datastore: %s, namespace: %s, snapshot: %s]",
 		b.job.Store, b.job.Namespace, b.job.Snapshot,
@@ -432,6 +438,10 @@ func (b *restoreJob) localExecute(ctx context.Context) error {
 	)
 	if err != nil {
 		return err
+	}
+
+	if b.disablePayloadCache {
+		reader.DisablePayloadCache()
 	}
 
 	b.localClient, b.errCh = pxar.NewLocalClient(reader, b.job.ID)

--- a/internal/server/web/api/restore_handlers.go
+++ b/internal/server/web/api/restore_handlers.go
@@ -181,6 +181,16 @@ func ExtJsRestoreHandler(storeInstance *store.Store) http.HandlerFunc {
 			}
 		}
 
+		payloadCacheChunks, err := strconv.Atoi(r.FormValue("payload-cache-chunks"))
+		if err != nil {
+			if r.FormValue("payload-cache-chunks") == "" {
+				payloadCacheChunks = 0
+			} else {
+				WriteErrorResponse(w, err)
+				return
+			}
+		}
+
 		id := r.FormValue("id")
 		if err := validate.ValidateJobId(id); err != nil && id != "" {
 			WriteErrorResponse(w, err)
@@ -230,19 +240,20 @@ func ExtJsRestoreHandler(storeInstance *store.Store) http.HandlerFunc {
 		}
 
 		newRestore := database.Restore{
-			ID:            id,
-			Store:         store,
-			Namespace:     namespace,
-			Snapshot:      snapshot,
-			SrcPath:       srcPath,
-			Mode:          mode,
-			DestTarget:    database.Target{Name: r.FormValue("dest-target")},
-			DestSubpath:   destSubpath,
-			PreScript:     preScript,
-			PostScript:    postScript,
-			Comment:       r.FormValue("comment"),
-			Retry:         retry,
-			RetryInterval: retryInterval,
+			ID:                 id,
+			Store:              store,
+			Namespace:          namespace,
+			Snapshot:           snapshot,
+			SrcPath:            srcPath,
+			Mode:               mode,
+			PayloadCacheChunks: payloadCacheChunks,
+			DestTarget:         database.Target{Name: r.FormValue("dest-target")},
+			DestSubpath:        destSubpath,
+			PreScript:          preScript,
+			PostScript:         postScript,
+			Comment:            r.FormValue("comment"),
+			Retry:              retry,
+			RetryInterval:      retryInterval,
 		}
 
 		err = storeInstance.RestoreSvc.CreateRestore(newRestore)
@@ -349,6 +360,12 @@ func ExtJsRestoreSingleHandler(storeInstance *store.Store) http.HandlerFunc {
 
 			restore.Mode = mode
 
+			payloadCacheChunks, pccErr := strconv.Atoi(r.FormValue("payload-cache-chunks"))
+			if pccErr != nil {
+				payloadCacheChunks = 0
+			}
+			restore.PayloadCacheChunks = payloadCacheChunks
+
 			retry, err := strconv.Atoi(r.FormValue("retry"))
 			if err != nil {
 				retry = 0
@@ -385,6 +402,8 @@ func ExtJsRestoreSingleHandler(storeInstance *store.Store) http.HandlerFunc {
 						restore.Comment = ""
 					case "mode":
 						restore.Mode = 0
+					case "payload-cache-chunks":
+						restore.PayloadCacheChunks = 0
 					case "retry":
 						restore.Retry = 0
 					case "retry-interval":

--- a/internal/server/web/views/custom/windows/restore.js
+++ b/internal/server/web/views/custom/windows/restore.js
@@ -250,6 +250,19 @@ Ext.define("PBS.D2DManagement.RestoreJobEdit", {
               deleteEmpty: "{!isCreate}",
             },
           },
+          {
+            xtype: "proxmoxintegerfield",
+            name: "payload-cache-chunks",
+            fieldLabel: gettext("Payload Cache Chunks"),
+            minValue: 0,
+            maxValue: 128,
+            value: 0,
+            allowBlank: true,
+            emptyText: "0 (lowest memory)",
+            cbind: {
+              deleteEmpty: "{!isCreate}",
+            },
+          },
         ],
 
         columnB: [


### PR DESCRIPTION
## Summary

Binds restore memory to a configurable limit by replacing the unbounded chunk cache with a user-tunable eviction-based cache.

### pxar library changes (v0.16.7)
- `SetCacheSize(n int)` on `ChunkedReadSeeker` — `0` disables cache entirely, `>0` caps to `n` chunks with LRU eviction
- `SetPayloadCacheSize(n int)` on `SplitArchiveReader` — delegates to payload reader

### pbs-plus changes
- **Database**: Migration `000023` adds `payload_cache_chunks INTEGER NOT NULL DEFAULT 0`
- **API**: Parses `payload-cache-chunks` from form data in POST/PUT handlers
- **Restore job**: Reads configured value and calls `reader.SetPayloadCacheSize(n)`
- **Web UI**: Integer field (0–128) in the restore job editor — `0` = no cache (lowest memory)
- **Buffer pooling**: `sync.Pool` for 256KB copy buffers in `restoreFile`
- **Thread safety**: `atomic.Bool` for `PxarReader.closed`

### Before
- `maxCache=64` chunks × 1–4MB each = up to **256MB** cached in memory
- Per-file 256KB buffer allocations (GC pressure)

### After
- Default `0` = **no cache** → memory stays under 100MB for any document
- Users can tune up to 128 chunks for speed/memory tradeoff
- Copy buffers pooled and reused

## Test plan
- [ ] Restore a large VM disk with `payload-cache-chunks=0` — verify memory stays <100MB
- [ ] Restore with `payload-cache-chunks=32` — verify improved speed, memory proportional
- [ ] Verify web UI field appears in restore job editor and persists correctly
- [ ] Verify existing restores (without the field) default to 0