### PR TITLE
fix(pxar-mount): resolve setfacl EIO by making ensureNode atomic and fixing ListXAttr

### DIFF
--- a/internal/pxarmount/journal.go
+++ b/internal/pxarmount/journal.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	_ "modernc.org/sqlite"
 )
@@ -715,6 +716,117 @@ func (j *Journal) AllWhiteouts() (map[int64][]string, error) {
 		result[parentID] = append(result[parentID], name)
 	}
 	return result, rows.Err()
+}
+
+// EnsureNodePath atomically creates a journal node and all intermediate
+// edges/nodes for the given path in a single transaction.
+// If whiteout is true and the entry has a pxar counterpart, a whiteout is added.
+// This is the efficient, atomic replacement for the multi-transaction
+// ensureNode path walk.
+func (j *Journal) EnsureNodePath(path string, n *GraphNode, whiteout bool) (int64, error) {
+	var nodeID int64
+	err := j.tx(func(tx *sql.Tx) error {
+		id, err := createNodeTx(tx, n)
+		if err != nil {
+			return err
+		}
+		nodeID = id
+
+		// Walk path components from root.
+		parts := splitPath(path)
+		curParentID := int64(1) // root
+
+		for i, name := range parts {
+			if name == "" {
+				continue
+			}
+
+			// Check if edge already exists.
+			var childID int64
+			err := tx.QueryRow(
+				`SELECT child_id FROM edges WHERE parent_id = ? AND name = ?`,
+				curParentID, name).Scan(&childID)
+			if err != nil && err != sql.ErrNoRows {
+				return err
+			}
+
+			if err == nil {
+				// Edge exists, follow it.
+				curParentID = childID
+				continue
+			}
+
+			// No edge — clean up any stale whiteout.
+			_, _ = tx.Exec(`DELETE FROM whiteouts WHERE parent_id = ? AND name = ?`, curParentID, name)
+
+			if i == len(parts)-1 {
+				// Final component — link to our node.
+				if _, err := tx.Exec(
+					`INSERT OR REPLACE INTO edges (parent_id, name, child_id) VALUES (?, ?, ?)`,
+					curParentID, name, nodeID); err != nil {
+					return err
+				}
+				if whiteout {
+					if _, err := tx.Exec(
+						`INSERT OR IGNORE INTO whiteouts (parent_id, name) VALUES (?, ?)`,
+						curParentID, name); err != nil {
+						return err
+					}
+				}
+			} else {
+				// Intermediate directory — create redirect node.
+				var intermediatePath strings.Builder
+				intermediatePath.WriteByte('/')
+				intermediatePath.WriteString(parts[0])
+				for j := 1; j <= i; j++ {
+					intermediatePath.WriteByte('/')
+					intermediatePath.WriteString(parts[j])
+				}
+				intermediate := &GraphNode{
+					Kind:       NodeDir,
+					Mode:       syscall.S_IFDIR | 0o755,
+					UID:        n.UID,
+					GID:        n.GID,
+					MtimeNs:    n.MtimeNs,
+					CtimeNs:    n.CtimeNs,
+					RedirectTo: intermediatePath.String(),
+				}
+				midID, err := createNodeTx(tx, intermediate)
+				if err != nil {
+					return err
+				}
+				if _, err := tx.Exec(
+					`INSERT OR REPLACE INTO edges (parent_id, name, child_id) VALUES (?, ?, ?)`,
+					curParentID, name, midID); err != nil {
+					return err
+				}
+				curParentID = midID
+			}
+		}
+		return nil
+	})
+	return nodeID, err
+}
+
+// splitPath splits a path into components.
+func splitPath(path string) []string {
+	if path == "/" || path == "" {
+		return nil
+	}
+	p := path
+	if p[0] == '/' {
+		p = p[1:]
+	}
+	var parts []string
+	start := 0
+	for i := 0; i < len(p); i++ {
+		if p[i] == '/' {
+			parts = append(parts, p[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, p[start:])
+	return parts
 }
 
 // Clear truncates all tables (keeps root node).

--- a/internal/pxarmount/mutablefs.go
+++ b/internal/pxarmount/mutablefs.go
@@ -1105,7 +1105,24 @@ func (fs *MutableFS) ListXAttr(cancel <-chan struct{}, header *fuse.InHeader, de
 	if re.PxarNode != nil {
 		pxarHeader := *header
 		pxarHeader.NodeId = re.PxarNode.inode
-		_, _ = fs.pxar.ListXAttr(cancel, &pxarHeader, nil)
+		// First call with nil dest to get total size.
+		pxarSz, pxarStatus := fs.pxar.ListXAttr(cancel, &pxarHeader, nil)
+		if pxarStatus == fuse.OK && pxarSz > 0 {
+			buf := make([]byte, pxarSz)
+			sz, status := fs.pxar.ListXAttr(cancel, &pxarHeader, buf)
+			if status == fuse.OK {
+				// Parse null-delimited names from the buffer.
+				start := 0
+				for i := 0; i <= int(sz); i++ {
+					if i == int(sz) || buf[i] == 0 {
+						if i > start {
+							nameSet[string(buf[start:i])] = true
+						}
+						start = i + 1
+					}
+				}
+			}
+		}
 	}
 
 	var total uint32
@@ -1561,6 +1578,7 @@ func (fs *MutableFS) resolveParentNodeID(parentPath string) int64 {
 // ensureNode ensures a journal node+edge exists for a resolved entry.
 // For pxar-only entries, it creates a node with redirect_to and an edge
 // under the parent. For journal entries, it's a no-op.
+// All database operations are batched into a single SQLite transaction.
 func (fs *MutableFS) ensureNode(re *ResolvedEntry) {
 	if re.Node != nil {
 		return
@@ -1588,78 +1606,12 @@ func (fs *MutableFS) ensureNode(re *ResolvedEntry) {
 		node.RedirectTo = re.Path
 	}
 
-	nodeID, err := fs.journal.CreateNode(node)
+	nodeID, err := fs.journal.EnsureNodePath(re.Path, node, false)
 	if err != nil {
+		fs.debugf("ensureNode: EnsureNodePath(%q) failed: %v", re.Path, err)
 		return
 	}
 	node.ID = nodeID
-
-	// Create edges for any parent nodes that don't already have them.
-	// Walk path from root, creating edges and intermediate nodes as needed.
-	parts := splitPath(re.Path)
-	curParentID := int64(1) // root
-
-	for i, name := range parts {
-		if name == "" {
-			continue
-		}
-		childID, err := fs.journal.LookupEdge(curParentID, name)
-		if err != nil {
-			return
-		}
-		if childID != 0 {
-			curParentID = childID
-			continue
-		}
-
-		if i == len(parts)-1 {
-			// This is the target — use our node.
-			if err := fs.journal.CreateEdge(curParentID, name, nodeID); err != nil {
-				return
-			}
-			// Add whiteout if shadowing pxar.
-			if re.PxarNode != nil {
-				if err := fs.journal.AddWhiteout(curParentID, name); err != nil {
-					fs.logNonFatal("add-whiteout", name, err)
-				}
-			}
-		} else {
-			// Intermediate directory — create inline.
-			var intermediatePath strings.Builder
-			intermediatePath.WriteString("/" + parts[0])
-			for j := 1; j <= i; j++ {
-				intermediatePath.WriteString("/" + parts[j])
-			}
-			intermediate := &GraphNode{
-				Kind:       NodeDir,
-				Mode:       syscall.S_IFDIR | 0o755,
-				UID:        node.UID,
-				GID:        node.GID,
-				Size:       0,
-				MtimeNs:    now,
-				CtimeNs:    now,
-				RedirectTo: intermediatePath.String(),
-			}
-			midID, err := fs.journal.CreateNode(intermediate)
-			if err != nil {
-				return
-			}
-			intermediate.ID = midID
-			if err := fs.journal.CreateEdge(curParentID, name, midID); err != nil {
-				return
-			}
-			curParentID = midID
-		}
-
-		// Check pxar whiteouts.
-		isWO, _ := fs.journal.IsWhiteout(curParentID, name)
-		if isWO {
-			if err := fs.journal.RemoveWhiteout(curParentID, name); err != nil {
-				fs.logNonFatal("remove-whiteout", name, err)
-			}
-		}
-	}
-
 	re.Node = node
 }
 
@@ -1929,27 +1881,6 @@ func fillAttrFromNode(attr *fuse.Attr, n *GraphNode) {
 	attr.Uid = n.UID
 	attr.Gid = n.GID
 	attr.Blksize = 4096
-}
-
-// splitPath splits a path into components.
-func splitPath(path string) []string {
-	if path == "/" || path == "" {
-		return nil
-	}
-	p := path
-	if p[0] == '/' {
-		p = p[1:]
-	}
-	var parts []string
-	start := 0
-	for i := 0; i < len(p); i++ {
-		if p[i] == '/' {
-			parts = append(parts, p[start:i])
-			start = i + 1
-		}
-	}
-	parts = append(parts, p[start:])
-	return parts
 }
 
 func munmap(data []byte) error {


### PR DESCRIPTION
## Problem

Running `setfacl -R` on an entire pxar-mount in read-write mode causes widespread `Input/output error` (EIO), making the mount inaccessible.

## Root Causes

### 1. `ensureNode` issued dozens of SQLite transactions per file
`ensureNode` was calling `CreateNode`, `CreateEdge`, `AddWhiteout`, `RemoveWhiteout` as **separate transactions** (each with a WAL checkpoint). For `setfacl -R` across thousands of files, this caused massive lock contention and FUSE request timeouts → EIO.

**Fix:** New `EnsureNodePath` method in `journal.go` batches all node/edge operations into a **single SQLite transaction**, including intermediate directory node creation.

### 2. `ensureNode` created whiteouts for metadata-only changes
When `setfacl` sets ACL xattrs on pxar-only entries, `ensureNode` added whiteouts — semantically wrong for overlay operations that don't replace the pxar entry. Whiteouts are only needed for actual mutations (create, delete, rename), which already handle them explicitly.

**Fix:** Removed whiteout creation from `ensureNode`. It now passes `whiteout=false` to `EnsureNodePath`.

### 3. `ListXAttr` silently discarded pxar xattr names
The pxar fallback call in `ListXAttr` invoked `fs.pxar.ListXAttr()` but discarded the result — the names were never added to the merge set. Only journal xattrs were returned.

**Fix:** Properly collect pxar xattr names by doing a two-pass: size query first, then buffer read, then parse null-delimited names into the nameSet.

## Files Changed
- `internal/pxarmount/journal.go` — added `EnsureNodePath` (atomic) and `splitPath` (moved from mutablefs)
- `internal/pxarmount/mutablefs.go` — rewrote `ensureNode` to use atomic path; fixed `ListXAttr`

## Testing
- Full project builds clean (`go build ./...`)
- All existing tests pass (`go test ./...`)