### PR TITLE
fix(backup): handle spurious PBS proxy connection error race

### DIFF
--- a/internal/server/backup/pbs_logging.go
+++ b/internal/server/backup/pbs_logging.go
@@ -32,6 +32,18 @@ var (
 		"TASK ERROR:",
 	}
 
+	// PBS proxy logs these when the h2 connection drops after backup
+	// completion. They are not real backup failures.
+	pbsSpuriousErrorPatterns = []string{
+		"connection error:",
+	}
+
+	// Client log markers that indicate successful backup completion.
+	pbsClientCompletionMarkers = []string{
+		"Duration: ",
+		"End Time: ",
+	}
+
 	pbsUploadErrorMarkers = []string{
 		"upload failed:",
 	}
@@ -132,6 +144,7 @@ func processPBSProxyLogs(
 	tmpWriter := bufio.NewWriter(tmpFile)
 
 	hasError := false
+	hasOnlySpuriousError := true
 	incomplete := true
 	alreadyHasClientLogs := false
 
@@ -151,6 +164,9 @@ func processPBSProxyLogs(
 			incomplete = false
 		} else if _, has := containsAny(line, pbsTaskErrorMarkers); has {
 			hasError = true
+			if _, spurious := containsAny(line, pbsSpuriousErrorPatterns); !spurious {
+				hasOnlySpuriousError = false
+			}
 			skip = true
 		}
 
@@ -170,6 +186,7 @@ func processPBSProxyLogs(
 	}
 
 	pbsWarningRawCount := 0
+	clientCompleted := false
 
 	clientFile, err := os.Open(clientLogFile.Path)
 	if err != nil {
@@ -189,6 +206,10 @@ func processPBSProxyLogs(
 
 			if _, has := containsAny(line, pbsWarningMarkers); has {
 				pbsWarningRawCount++
+			}
+
+			if _, has := containsAny(line, pbsClientCompletionMarkers); has {
+				clientCompleted = true
 			}
 
 			if _, has := containsAny(line, pbsUploadErrorMarkers); has {
@@ -219,6 +240,16 @@ func processPBSProxyLogs(
 	cancelled := false
 	warningsNum := pbsWarningRawCount
 	timestamp := time.Now().In(systemLocation()).Format(time.RFC3339)
+
+	// If the only error from the PBS proxy is a spurious connection
+	// error (h2 connection dropped after backup completion) and the
+	// client log shows evidence of successful completion, treat the
+	// backup as successful rather than failed.
+	if hasError && hasOnlySpuriousError && clientCompleted {
+		hasError = false
+		incomplete = false
+		isGraceful = true
+	}
 
 	switch {
 	case hasError, incomplete:


### PR DESCRIPTION
When the h2 connection drops after backup completion but before PBS proxy's finished() check, PBS writes `TASK ERROR: connection error: not connected` even though the backup succeeded.

This detects the race by checking if the proxy error is only a connection error and the client log contains completion markers (Duration/End Time), then treats it as a successful backup instead of a failure.