### PR TITLE
refactor(verification): remove MaxFileSize, merge into file filters

### DIFF
--- a/internal/server/database/types.go
+++ b/internal/server/database/types.go
@@ -270,7 +270,6 @@ type SpotCheckConfig struct {
 	DateFrom         string            `json:"date_from"` // RFC3339 or empty
 	DateTo           string            `json:"date_to"`   // RFC3339 or empty
 	Filters          []SpotCheckFilter `json:"filters"`
-	MaxFileSize      int64             `json:"max_file_size"`  // skip files larger than this (0 = no limit)
 	FailThreshold    int               `json:"fail_threshold"` // stop after N failures (0 = no limit)
 }
 

--- a/internal/server/verification/job.go
+++ b/internal/server/verification/job.go
@@ -838,11 +838,6 @@ func (v *verificationJob) walkDir(fs *vfs.LocalFS, entry *pxar.FileInfo, prefix 
 	} else if entry.IsFile() && len(entry.ContentRange) == 2 {
 		filePath := prefix
 
-		// Skip files exceeding max_file_size limit
-		if cfg.MaxFileSize > 0 && entry.Size() > cfg.MaxFileSize {
-			return files, nil
-		}
-
 		if !v.matchesFilters(filePath, entry, cfg) {
 			return files, nil
 		}

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -209,12 +209,6 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 
 		useLatest := r.FormValue("use_latest") == "true"
 
-		var maxFileSize int64
-		if mfs := r.FormValue("max_file_size"); mfs != "" {
-			if n, err := strconv.ParseInt(mfs, 10, 64); err == nil && n > 0 {
-				maxFileSize = n
-			}
-		}
 		var failThreshold int
 		if ft := r.FormValue("fail_threshold"); ft != "" {
 			if n, err := strconv.Atoi(ft); err == nil && n > 0 {
@@ -270,7 +264,6 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 				UseLatest:        useLatest,
 				DateFrom:         r.FormValue("date_from"),
 				DateTo:           r.FormValue("date_to"),
-				MaxFileSize:      maxFileSize,
 				FailThreshold:    failThreshold,
 			},
 			RunOnBackupComplete: r.FormValue("run_on_backup_complete") == "true",
@@ -305,9 +298,7 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 				if len(sc.Filters) > 0 {
 					job.SpotConfig.Filters = sc.Filters
 				}
-				if sc.MaxFileSize > 0 {
-					job.SpotConfig.MaxFileSize = sc.MaxFileSize
-				}
+
 				if sc.FailThreshold > 0 {
 					job.SpotConfig.FailThreshold = sc.FailThreshold
 				}
@@ -435,11 +426,7 @@ func ExtJsVerificationConfigSingleHandler(storeInstance *store.Store) http.Handl
 			if filtersJSON := r.FormValue("filters"); filtersJSON != "" {
 				_ = json.Unmarshal([]byte(filtersJSON), &job.SpotConfig.Filters)
 			}
-			if v := r.FormValue("max_file_size"); v != "" {
-				if n, err := strconv.ParseInt(v, 10, 64); err == nil {
-					job.SpotConfig.MaxFileSize = n
-				}
-			}
+
 			if v := r.FormValue("fail_threshold"); v != "" {
 				if n, err := strconv.Atoi(v); err == nil {
 					job.SpotConfig.FailThreshold = n

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -478,37 +478,6 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
 
   column2: [
     {
-      xtype: "fieldcontainer",
-      fieldLabel: gettext("Max File Size"),
-      layout: "hbox",
-      items: [
-        {
-          xtype: "numberfield",
-          name: "max_file_size_val",
-          minValue: 0,
-          decimalPrecision: 2,
-          flex: 1,
-          value: 0,
-          emptyText: gettext("No limit"),
-          listeners: {},
-        },
-        {
-          xtype: "combo",
-          name: "max_file_size_unit",
-          store: sizeUnitStore,
-          displayField: "display",
-          valueField: "value",
-          queryMode: "local",
-          editable: false,
-          anyMatch: true,
-          forceSelection: true,
-          value: 1048576,
-          width: 80,
-          margin: "0 0 0 5",
-        },
-      ],
-    },
-    {
       xtype: "numberfield",
       fieldLabel: gettext("Fail Threshold"),
       name: "fail_threshold",
@@ -533,12 +502,6 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       name: "filters",
       reference: "filtersHidden",
       value: "[]",
-    },
-    {
-      xtype: "hiddenfield",
-      name: "max_file_size",
-      reference: "maxFileSizeHidden",
-      value: "0",
     },
     {
       xtype: "fieldset",
@@ -692,16 +655,6 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       }
     }
 
-    // Restore max_file_size composite field from raw bytes
-    var maxBytes = values.max_file_size || 0;
-    if (maxBytes > 0) {
-      var unit = bestUnitForBytes(maxBytes);
-      var valField = me.down("[name=max_file_size_val]");
-      var unitField = me.down("[name=max_file_size_unit]");
-      if (valField) valField.setValue(maxBytes / unit.get("value"));
-      if (unitField) unitField.setValue(unit.get("value"));
-    }
-
     // Update strategy description
     if (values.sampling_strategy) {
       var descBox = me.down("[reference=strategyDesc]");
@@ -716,17 +669,6 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
   getValues: function () {
     var me = this;
     var vals = me.callParent(arguments);
-
-    // Convert max_file_size composite field to raw bytes
-    var maxVal = parseFloat(vals.max_file_size_val) || 0;
-    var maxFactor = parseInt(vals.max_file_size_unit, 10) || 1;
-    vals.max_file_size = Math.round(maxVal * maxFactor);
-    delete vals.max_file_size_val;
-    delete vals.max_file_size_unit;
-
-    // Clean up hidden field value
-    delete vals["max_file_size"];
-
     return vals;
   },
 });


### PR DESCRIPTION
The per-filter MinSize/MaxSize already applies during directory walk via matchesFilters(). The global MaxFileSize was redundant — filters now provide the same capability with path pattern targeting.

Changes:
- Remove MaxFileSize from SpotCheckConfig struct
- Remove MaxFileSize from API create/update handlers
- Remove MaxFileSize skip from walkDir (matchesFilters already handles it)
- Remove Max File Size composite field from Spot Check Settings UI
- Remove hidden field, setValues/getValues cleanup