### PR TITLE
feat(verification): TCP fork pattern, pre-stat, job cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pbs-plus-agent
 *.exe
 /pxar-mount
 internal/pxarmount/journal.db
+pbs-plus-server

--- a/internal/agent/cli/entry.go
+++ b/internal/agent/cli/entry.go
@@ -24,7 +24,7 @@ func Entry() {
 	token := flag.String("token", "", "Auth Token")
 	flag.Parse()
 
-	if *cmdMode != "restore" && *cmdMode != "backup" {
+	if *cmdMode != "restore" && *cmdMode != "backup" && *cmdMode != "verify" {
 		syslog.L.Debug().WithMessage("cli: invalid command mode").WithField("cmdMode", *cmdMode).Write()
 		return
 	}
@@ -86,5 +86,7 @@ func Entry() {
 		cmdBackup(sourceMode, readMode, drive, id)
 	case "restore":
 		cmdRestore(id, srcPath, destPath, restoreMode)
+	case "verify":
+		cmdVerify(id)
 	}
 }

--- a/internal/agent/cli/verify.go
+++ b/internal/agent/cli/verify.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	cryptoRand "crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containers/winquit/pkg/winquit"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/pbs-plus/pbs-plus/internal/agent"
+	"github.com/pbs-plus/pbs-plus/internal/agent/registry"
+	agentverification "github.com/pbs-plus/pbs-plus/internal/agent/verification"
+	"github.com/pbs-plus/pbs-plus/internal/arpc"
+	"github.com/pbs-plus/pbs-plus/internal/conf"
+	"github.com/pbs-plus/pbs-plus/internal/syslog"
+	"github.com/pbs-plus/pbs-plus/internal/validate"
+)
+
+func ExecVerification(verifyID string) (int, error) {
+	syslog.L.Info().WithMessage("verify: exec begin").
+		WithField("verifyID", verifyID).
+		Write()
+
+	if err := validate.ValidateJobId(verifyID); err != nil {
+		return -1, fmt.Errorf("invalid verifyID: %w", err)
+	}
+
+	tokenBytes := make([]byte, 32)
+	if _, err := cryptoRand.Read(tokenBytes); err != nil {
+		return -1, err
+	}
+	token := base64.StdEncoding.EncodeToString(tokenBytes)
+
+	tokenFile := filepath.Join(os.TempDir(), fmt.Sprintf(".pbs-plus-token-verify-%s", verifyID))
+	if err := os.WriteFile(tokenFile, []byte(token), 0600); err != nil {
+		return -1, err
+	}
+
+	defer func() {
+		time.Sleep(5 * time.Second)
+		os.Remove(tokenFile)
+	}()
+
+	execCmd, err := os.Executable()
+	if err != nil {
+		return -1, err
+	}
+
+	args := []string{
+		"--cmdMode=verify",
+		"--id=" + verifyID,
+		"--token=" + token,
+	}
+
+	cmd := exec.Command(execCmd, args...)
+	setProcAttributes(cmd)
+	cmd.Env = os.Environ()
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return -1, err
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return -1, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return -1, err
+	}
+	syslog.L.Info().WithMessage("verify: child process started").
+		WithField("pid", cmd.Process.Pid).
+		WithField("args", strings.Join(args, " ")).
+		Write()
+
+	go func() {
+		for scanner := bufio.NewScanner(stdoutPipe); scanner.Scan(); {
+			syslog.L.Info().
+				WithField("verifyID", verifyID).
+				WithField("forked", true).
+				WithMessage(scanner.Text()).Write()
+		}
+	}()
+
+	go func() {
+		for errScanner := bufio.NewScanner(stderrPipe); errScanner.Scan(); {
+			syslog.L.Error(errors.New(errScanner.Text())).
+				WithField("verifyID", verifyID).
+				WithField("forked", true).
+				Write()
+		}
+	}()
+
+	syslog.L.Info().WithMessage("verify: returning to parent").
+		WithField("pid", cmd.Process.Pid).
+		Write()
+
+	return cmd.Process.Pid, nil
+}
+
+func cmdVerify(verifyID *string) {
+	if *verifyID == "" {
+		fmt.Fprintln(os.Stderr, "Error: verifyID is required")
+		os.Exit(1)
+	}
+
+	if err := validate.ValidateJobId(*verifyID); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: invalid verifyID: %v\n", err)
+		os.Exit(1)
+	}
+
+	serverUrl, err := registry.GetEntry(registry.CONFIG, "ServerURL", false)
+	if err != nil {
+		syslog.L.Error(err).WithMessage("verify: failed to get server URL").Write()
+		os.Exit(1)
+	}
+	uri, err := agent.ParseURI(serverUrl.Value)
+	if err != nil {
+		syslog.L.Error(err).WithMessage("verify: failed to parse URI").Write()
+		os.Exit(1)
+	}
+	tlsConfig, err := agent.GetTLSConfig()
+	if err != nil {
+		syslog.L.Error(err).WithMessage("verify: failed to get TLS config").Write()
+		os.Exit(1)
+	}
+
+	address := fmt.Sprintf("%s%s", strings.TrimSuffix(uri.Hostname(), ":"), conf.ARPCServerPort)
+	headers := http.Header{}
+	headers.Add("X-PBS-Plus-VerifyID", *verifyID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+	winquit.SimulateSigTermOnQuit(done)
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		defer syslog.L.Info().WithMessage("verify: arpc session handler shutting down").Write()
+
+		syslog.L.Info().WithMessage("verify: attempting connection").WithField("verifyID", *verifyID).Write()
+
+		session, err := arpc.ConnectToServer(ctx, address, headers, tlsConfig)
+		if err != nil {
+			if strings.Contains(err.Error(), "(code 403)") {
+				syslog.L.Error(err).WithMessage("verify: authorization failed, shutting down").Write()
+			} else {
+				syslog.L.Error(err).WithMessage("verify: connection failed").Write()
+			}
+			cancel()
+			return
+		}
+		defer session.Close()
+
+		router := arpc.NewRouter()
+		router.Handle("verify_chunk_file", agentverification.VerifyChunkFileHandler)
+		session.SetRouter(router)
+
+		syslog.L.Info().WithMessage("verify: session ready, serving").
+			WithField("verifyID", *verifyID).
+			Write()
+
+		if err := session.Serve(); err != nil {
+			syslog.L.Warn().WithMessage("verify: ARPC session ended").WithField("error", err.Error()).Write()
+		}
+	})
+
+	go func() {
+		sig := <-done
+		syslog.L.Info().WithMessage(fmt.Sprintf("verify: received signal %v", sig)).Write()
+		cancel()
+	}()
+
+	wg.Wait()
+
+	syslog.L.Info().WithMessage("verify: finished").Write()
+	os.Exit(0)
+}
+
+// VerifyStartHandler is the ARPC handler that forks a verification worker
+// process. The forked process connects back to the server via TCP.
+func VerifyStartHandler(req *arpc.Request) (arpc.Response, error) {
+	var reqData agentverification.VerifyStartReq
+	if err := cbor.Unmarshal(req.Payload, &reqData); err != nil {
+		return arpc.Response{}, err
+	}
+
+	pid, err := ExecVerification(reqData.VerifyID)
+	if err != nil {
+		return arpc.Response{}, err
+	}
+
+	return arpc.Response{Status: 200, Message: fmt.Sprintf("%d", pid)}, nil
+}

--- a/internal/agent/lifecycle/manager.go
+++ b/internal/agent/lifecycle/manager.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/pbs-plus/pbs-plus/internal/agent"
+	"github.com/pbs-plus/pbs-plus/internal/agent/cli"
 	"github.com/pbs-plus/pbs-plus/internal/agent/registry"
 	"github.com/pbs-plus/pbs-plus/internal/agent/sync"
-	agentverification "github.com/pbs-plus/pbs-plus/internal/agent/verification"
 	"github.com/pbs-plus/pbs-plus/internal/arpc"
 	"github.com/pbs-plus/pbs-plus/internal/conf"
 	"github.com/pbs-plus/pbs-plus/internal/syslog"
@@ -301,7 +301,7 @@ func ConnectARPC(
 			router.Handle("target_status", sync.StatusHandler)
 			router.Handle("cleanup", sync.BackupCloseHandler)
 			router.Handle("cleanup_restore", sync.RestoreCloseHandler)
-			router.Handle("verify_chunk_file", agentverification.VerifyChunkFileHandler)
+			router.Handle("verify_start", cli.VerifyStartHandler)
 			session.SetRouter(router)
 			backoff = base
 

--- a/internal/agent/verification/handler.go
+++ b/internal/agent/verification/handler.go
@@ -29,8 +29,23 @@ type VerifyFileResp struct {
 	Error  string   `cbor:"error"`
 }
 
+// VerifyStartReq is the request payload for the verify_start control message.
+type VerifyStartReq struct {
+	VerifyID string `cbor:"verify_id"`
+}
+
 // HashFile computes the SHA-256 hash of a file.
 func HashFile(filePath string) ([32]byte, int64, error) {
+	// Fast existence check — avoids opening a file handle on a
+	// slow/network mount only to discover it's gone.
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return [32]byte{}, 0, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return [32]byte{}, 0, fmt.Errorf("not a regular file")
+	}
+
 	f, err := os.Open(filePath)
 	if err != nil {
 		return [32]byte{}, 0, fmt.Errorf("failed to open file: %w", err)
@@ -38,7 +53,6 @@ func HashFile(filePath string) ([32]byte, int64, error) {
 	defer func() { _ = f.Close() }()
 
 	h := sha256simd.New()
-
 	bufp := bufPool.Get().(*[]byte)
 	size, err := io.CopyBuffer(h, f, *bufp)
 	bufPool.Put(bufp)

--- a/internal/arpc/agents_manager.go
+++ b/internal/arpc/agents_manager.go
@@ -90,6 +90,11 @@ func (sm *AgentsManager) getClientId(state tls.ConnectionState, headers http.Hea
 		clientID = clientID + "|" + restoreIdHeader + "|restore"
 	}
 
+	verifyIdHeader := headers.Get("X-PBS-Plus-VerifyID")
+	if verifyIdHeader != "" {
+		clientID = clientID + "|" + verifyIdHeader + "|verify"
+	}
+
 	return clientID
 }
 

--- a/internal/server/verification/job.go
+++ b/internal/server/verification/job.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pbs-plus/pbs-plus/internal/agent/verification"
+	"github.com/pbs-plus/pbs-plus/internal/arpc"
 	"github.com/pbs-plus/pbs-plus/internal/server/database"
 	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
 	"github.com/pbs-plus/pbs-plus/internal/server/proxmox"
@@ -43,7 +44,47 @@ var (
 			return &buf
 		},
 	}
+
+	// activeJobs tracks currently running verification jobs for cancellation.
+	activeJobs = struct {
+		sync.RWMutex
+		m map[string]context.CancelFunc
+	}{m: make(map[string]context.CancelFunc)}
 )
+
+// RegisterJob registers a running verification job for cancellation tracking.
+func RegisterJob(jobID string, cancel context.CancelFunc) {
+	activeJobs.Lock()
+	activeJobs.m[jobID] = cancel
+	activeJobs.Unlock()
+}
+
+// UnregisterJob removes a finished verification job from tracking.
+func UnregisterJob(jobID string) {
+	activeJobs.Lock()
+	delete(activeJobs.m, jobID)
+	activeJobs.Unlock()
+}
+
+// StopJob cancels a running verification job. Returns false if not running.
+func StopJob(jobID string) bool {
+	activeJobs.RLock()
+	cancel, ok := activeJobs.m[jobID]
+	activeJobs.RUnlock()
+	if !ok {
+		return false
+	}
+	cancel()
+	return true
+}
+
+// IsJobRunning checks if a verification job is currently running.
+func IsJobRunning(jobID string) bool {
+	activeJobs.RLock()
+	_, ok := activeJobs.m[jobID]
+	activeJobs.RUnlock()
+	return ok
+}
 
 // readerFunc adapts a function to io.Reader for context-aware reads.
 type readerFunc func([]byte) (int, error)
@@ -236,24 +277,57 @@ func (v *verificationJob) execute(ctx context.Context) error {
 			continue
 		}
 
-		// Try to get agent connection
+		// Get the agent's main control session (QUIC or TCP) to send the fork command.
 		hostname := backup.Target.GetHostname()
-		var agentCaller interface {
-			Call(ctx context.Context, method string, payload any, out any) error
+		streamID := hostname + "|" + job.ID + "|verify"
+
+		type caller interface {
+			CallMessage(ctx context.Context, method string, payload any) (string, error)
 		}
-		if sess, ok := v.storeInstance.ARPCAgentsManager.GetStreamPipe(hostname); ok {
-			agentCaller = sess
-		} else if sess, ok := v.storeInstance.ARPCAgentsManager.GetQuicPipe(hostname); ok {
-			agentCaller = sess
+		var controlSess caller
+		if sess, ok := v.storeInstance.ARPCAgentsManager.GetQuicPipe(hostname); ok {
+			controlSess = sess
+		} else if sess, ok := v.storeInstance.ARPCAgentsManager.GetStreamPipe(hostname); ok {
+			controlSess = sess
 		} else {
 			vTask.WriteString(fmt.Sprintf("skipping backup job '%s': agent '%s' not connected", backup.ID, hostname))
 			lastStartupErr = ErrAgentNotConnected
 			continue
 		}
 
+		// Send verify_start control message to fork the worker process
+		v.storeInstance.ARPCAgentsManager.Expect(streamID)
+
+		verifyReq := verification.VerifyStartReq{VerifyID: job.ID}
+		forkCtx, forkCancel := context.WithTimeout(ctx, 30*time.Second)
+		_, forkErr := controlSess.CallMessage(forkCtx, "verify_start", &verifyReq)
+		forkCancel()
+		if forkErr != nil {
+			v.storeInstance.ARPCAgentsManager.NotExpect(streamID)
+			vTask.WriteString(fmt.Sprintf("skipping backup job '%s': failed to fork verification worker: %v", backup.ID, forkErr))
+			lastStartupErr = forkErr
+			continue
+		}
+
+		// Wait for the forked process to connect back via TCP
+		pipeCtx, pipeCancel := context.WithTimeout(ctx, 30*time.Second)
+		agentTCP, waitErr := v.storeInstance.ARPCAgentsManager.WaitStreamPipe(pipeCtx, streamID)
+		pipeCancel()
+		if waitErr != nil {
+			v.storeInstance.ARPCAgentsManager.NotExpect(streamID)
+			vTask.WriteString(fmt.Sprintf("skipping backup job '%s': verification worker did not connect: %v", backup.ID, waitErr))
+			lastStartupErr = waitErr
+			continue
+		}
+		// TCP session registered; NotExpect is no longer needed
+		v.storeInstance.ARPCAgentsManager.NotExpect(streamID)
+
+		vTask.WriteString(fmt.Sprintf("verification worker connected via TCP for job '%s'", backup.ID))
+
 		// Try to open the archive
 		vs, archiveErr := v.openArchive(backup, snapshot)
 		if archiveErr != nil {
+			agentTCP.Close()
 			vTask.WriteString(fmt.Sprintf("skipping backup job '%s' snapshot '%s': failed to open archive: %v", backup.ID, snapshot.Snapshot, archiveErr))
 			lastStartupErr = archiveErr
 			continue
@@ -262,7 +336,7 @@ func (v *verificationJob) execute(ctx context.Context) error {
 		vTask.WriteString(fmt.Sprintf("selected backup job '%s', snapshot: %s", backup.ID, snapshot.Snapshot))
 
 		// All startup checks passed — run verification for this snapshot
-		return v.executeVerification(ctx, vTask, job, backup, snapshot, vs, agentCaller)
+		return v.executeVerification(ctx, vTask, job, backup, snapshot, vs, agentTCP)
 	}
 
 	// All candidates exhausted
@@ -281,11 +355,10 @@ func (v *verificationJob) executeVerification(
 	backup database.Backup,
 	snapshot *snapshotInfo,
 	vs *verifyState,
-	agentCaller interface {
-		Call(ctx context.Context, method string, payload any, out any) error
-	},
+	agentTCP *arpc.StreamPipe,
 ) error {
 	defer func() { _ = vs.Close() }()
+	defer agentTCP.Close()
 
 	// Create a derived context so we can cancel remaining workers on fail threshold
 	ctx, cancel := context.WithCancel(ctx)
@@ -362,7 +435,7 @@ func (v *verificationJob) executeVerification(
 				default:
 				}
 
-				fr := v.verifyFile(ctx, agentCaller, vs, sampledFiles[idx], backup)
+				fr := v.verifyFile(ctx, agentTCP, vs, sampledFiles[idx], backup)
 				resultsCh <- indexedResult{index: idx, result: fr}
 			}
 		})
@@ -979,9 +1052,7 @@ func (v *verificationJob) matchesFilters(path string, entry *pxar.FileInfo, cfg 
 // stored pxar archive.
 func (v *verificationJob) verifyFile(
 	ctx context.Context,
-	agentCaller interface {
-		Call(ctx context.Context, method string, payload any, out any) error
-	},
+	agentTCP *arpc.StreamPipe,
 	vs *verifyState,
 	file fileEntry,
 	backup database.Backup,
@@ -1016,7 +1087,9 @@ func (v *verificationJob) verifyFile(
 
 	go func() {
 		var resp verification.VerifyFileResp
-		err := agentCaller.Call(ctx, "verify_chunk_file", verification.VerifyFileReq{FilePath: agentPath}, &resp)
+		fileCtx, fileCancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer fileCancel()
+		err := agentTCP.Call(fileCtx, "verify_chunk_file", verification.VerifyFileReq{FilePath: agentPath}, &resp)
 		agentCh <- agentResult{resp: resp, err: err}
 	}()
 

--- a/internal/server/verification/job.go
+++ b/internal/server/verification/job.go
@@ -45,6 +45,11 @@ var (
 	}
 )
 
+// readerFunc adapts a function to io.Reader for context-aware reads.
+type readerFunc func([]byte) (int, error)
+
+func (rf readerFunc) Read(p []byte) (int, error) { return rf(p) }
+
 // fileEntry represents a file found in the pxar archive.
 type fileEntry struct {
 	Path         string
@@ -282,6 +287,10 @@ func (v *verificationJob) executeVerification(
 ) error {
 	defer func() { _ = vs.Close() }()
 
+	// Create a derived context so we can cancel remaining workers on fail threshold
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	vTask.WriteString(fmt.Sprintf("selected snapshot: %s", snapshot.Snapshot))
 
 	// Create result record
@@ -316,36 +325,94 @@ func (v *verificationJob) executeVerification(
 	v.mu.RUnlock()
 	vTask.WriteString(fmt.Sprintf("sampled %d files for verification", len(sampledFiles)))
 
-	// Verify each file
-	for i, file := range sampledFiles {
-		select {
-		case <-ctx.Done():
-			return jobs.ErrCanceled
-		default:
+	// Verify files concurrently with a bounded worker pool.
+	concurrency := 4
+	if n := len(sampledFiles); n < concurrency {
+		concurrency = n
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	type indexedResult struct {
+		index  int
+		result database.VerificationFileResult
+	}
+
+	filesCh := make(chan int, len(sampledFiles))
+	resultsCh := make(chan indexedResult, len(sampledFiles))
+
+	// Feed file indices
+	for i := range sampledFiles {
+		filesCh <- i
+	}
+	close(filesCh)
+
+	// Launch workers
+	var wg sync.WaitGroup
+	for w := 0; w < concurrency; w++ {
+		wg.Go(func() {
+			for idx := range filesCh {
+				select {
+				case <-ctx.Done():
+					resultsCh <- indexedResult{index: idx, result: database.VerificationFileResult{
+						Path: sampledFiles[idx].Path, Size: sampledFiles[idx].Size, Status: "skipped", Message: "canceled",
+					}}
+					continue
+				default:
+				}
+
+				fr := v.verifyFile(ctx, agentCaller, vs, sampledFiles[idx], backup)
+				resultsCh <- indexedResult{index: idx, result: fr}
+			}
+		})
+	}
+
+	// Close results channel when all workers finish
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	// Collect results. Since resultsCh is buffered to len(sampledFiles),
+	// workers never block on send. We drain all results to avoid goroutine leaks.
+	ordered := make([]database.VerificationFileResult, len(sampledFiles))
+	collected := 0
+	thresholdHit := false
+
+	for ir := range resultsCh {
+		collected++
+		if ir.result.Status != "" {
+			ordered[ir.index] = ir.result
 		}
 
-		fileResult := v.verifyFile(ctx, agentCaller, vs, file, backup)
-		result.Details = append(result.Details, fileResult)
-
-		switch fileResult.Status {
+		switch ir.result.Status {
 		case "ok":
 			result.VerifiedFiles++
 		case "failed":
 			result.FailedFiles++
-			vTask.WriteString(fmt.Sprintf("file verification failed: %s - %s", file.Path, fileResult.Message))
+			vTask.WriteString(fmt.Sprintf("file verification failed: %s - %s", ir.result.Path, ir.result.Message))
 		default:
 			result.SkippedFiles++
-			vTask.WriteString(fmt.Sprintf("file skipped: %s - %s", file.Path, fileResult.Message))
+			vTask.WriteString(fmt.Sprintf("file skipped: %s - %s", ir.result.Path, ir.result.Message))
 		}
 
-		// Fail threshold: stop early after N failures
-		if job.SpotConfig.FailThreshold > 0 && result.FailedFiles >= job.SpotConfig.FailThreshold {
+		// Fail threshold: cancel remaining work (workers will see ctx.Done())
+		if job.SpotConfig.FailThreshold > 0 && result.FailedFiles >= job.SpotConfig.FailThreshold && !thresholdHit {
+			thresholdHit = true
 			vTask.WriteString(fmt.Sprintf("fail threshold reached (%d failures), stopping verification", result.FailedFiles))
-			break
+			cancel()
 		}
 
-		if (i+1)%10 == 0 || i+1 == len(sampledFiles) {
-			vTask.WriteString(fmt.Sprintf("progress: %d/%d files verified", i+1, len(sampledFiles)))
+		if collected%10 == 0 || collected == len(sampledFiles) {
+			vTask.WriteString(fmt.Sprintf("progress: %d/%d files verified", collected, len(sampledFiles)))
+		}
+	}
+
+	// Append collected results in order
+	for _, fr := range ordered {
+		if fr.Status != "" {
+			result.Details = append(result.Details, fr)
 		}
 	}
 
@@ -356,8 +423,13 @@ func (v *verificationJob) executeVerification(
 	v.skippedFiles = result.SkippedFiles
 	v.mu.Unlock()
 
-	result.Status = "completed"
 	result.CompletedAt = time.Now().Unix()
+	switch {
+	case result.FailedFiles > 0:
+		result.Status = "warning"
+	default:
+		result.Status = "completed"
+	}
 
 	if err := v.storeInstance.Database.UpdateVerificationResult(*result); err != nil {
 		syslog.L.Error(err).WithField("jobID", job.ID).WithMessage("failed to update verification result").Write()
@@ -412,8 +484,8 @@ func (v *verificationJob) onSuccess() {
 		t.WriteString(fmt.Sprintf("End Time: %s", time.Now().Format("Mon Jan 2 15:04:05 2006")))
 
 		if failed > 0 {
-			t.CloseErr(fmt.Errorf("%d of %d files failed verification", failed, total))
-			if err := v.updateJobHistory(false, 0); err != nil {
+			t.CloseWarn(failed)
+			if err := v.updateJobHistory(true, failed); err != nil {
 				syslog.L.Error(err).WithField("jobID", v.job.ID).WithMessage("failed to update job history").Write()
 			}
 			return
@@ -920,7 +992,7 @@ func (v *verificationJob) verifyFile(
 		Status: "error",
 	}
 
-	// 1. Ask agent to hash the live file
+	// Compute agent path
 	rootPath := backup.Target.GetAgentHostPath()
 	relPath := strings.TrimPrefix(file.Path, "/")
 	if backup.Subpath != "" {
@@ -929,35 +1001,55 @@ func (v *verificationJob) verifyFile(
 	}
 	agentPath := filepath.Join(rootPath, relPath)
 
-	req := verification.VerifyFileReq{
-		FilePath: agentPath,
+	// Run agent hash and archive hash concurrently
+	type agentResult struct {
+		resp verification.VerifyFileResp
+		err  error
+	}
+	type archiveResult struct {
+		hash [32]byte
+		err  error
 	}
 
-	var agentResp verification.VerifyFileResp
-	if err := agentCaller.Call(ctx, "verify_chunk_file", req, &agentResp); err != nil {
+	agentCh := make(chan agentResult, 1)
+	archiveCh := make(chan archiveResult, 1)
+
+	go func() {
+		var resp verification.VerifyFileResp
+		err := agentCaller.Call(ctx, "verify_chunk_file", verification.VerifyFileReq{FilePath: agentPath}, &resp)
+		agentCh <- agentResult{resp: resp, err: err}
+	}()
+
+	go func() {
+		hash, err := extractFileHash(ctx, vs, file)
+		archiveCh <- archiveResult{hash: hash, err: err}
+	}()
+
+	agentRes := <-agentCh
+	if agentRes.err != nil {
 		result.Status = "skipped"
-		result.Message = fmt.Sprintf("agent call failed: %v", err)
+		result.Message = fmt.Sprintf("agent call failed: %v", agentRes.err)
+		<-archiveCh // drain
+		return result
+	}
+	if agentRes.resp.Error != "" {
+		result.Status = "skipped"
+		result.Message = agentRes.resp.Error
+		<-archiveCh // drain
 		return result
 	}
 
-	if agentResp.Error != "" {
-		result.Status = "skipped"
-		result.Message = agentResp.Error
-		return result
-	}
-
-	// 2. Extract file content from the stored archive and hash it
-	storedHash, err := extractFileHash(vs, file)
-	if err != nil {
+	archiveRes := <-archiveCh
+	if archiveRes.err != nil {
 		result.Status = "error"
-		result.Message = fmt.Sprintf("failed to extract file from archive: %v", err)
+		result.Message = fmt.Sprintf("failed to extract file from archive: %v", archiveRes.err)
 		return result
 	}
 
-	// 3. Compare hashes
-	if agentResp.SHA256 != storedHash {
+	// Compare hashes
+	if agentRes.resp.SHA256 != archiveRes.hash {
 		result.Status = "failed"
-		result.Message = fmt.Sprintf("SHA-256 mismatch: agent=%x, archive=%x", agentResp.SHA256, storedHash)
+		result.Message = fmt.Sprintf("SHA-256 mismatch: agent=%x, archive=%x", agentRes.resp.SHA256, archiveRes.hash)
 		return result
 	}
 
@@ -967,8 +1059,8 @@ func (v *verificationJob) verifyFile(
 }
 
 // extractFileHash reads a file's content from the pxar archive and returns
-// its SHA-256 hash.
-func extractFileHash(vs *verifyState, file fileEntry) ([32]byte, error) {
+// its SHA-256 hash. It respects context cancellation.
+func extractFileHash(ctx context.Context, vs *verifyState, file fileEntry) ([32]byte, error) {
 	rc, err := vs.fs.ReadContentReader(file.ContentStart, file.ContentEnd)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("failed to open content reader for [%d, %d): %w", file.ContentStart, file.ContentEnd, err)
@@ -977,8 +1069,16 @@ func extractFileHash(vs *verifyState, file fileEntry) ([32]byte, error) {
 
 	h := sha256simd.New()
 	bufp := bufPool.Get().(*[]byte)
-	_, err = io.CopyBuffer(h, rc, *bufp)
-	bufPool.Put(bufp)
+	defer bufPool.Put(bufp)
+
+	_, err = io.CopyBuffer(h, readerFunc(func(p []byte) (int, error) {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			return rc.Read(p)
+		}
+	}), *bufp)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("failed to read file content: %w", err)
 	}

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -113,7 +113,11 @@ func ExtJsVerificationRunHandler(storeInstance *store.Store) http.HandlerFunc {
 				}
 
 				if stop {
-					// TODO: implement stop via RPC
+					for _, jobID := range decodedJobIDs {
+						if !verification.StopJob(jobID) {
+							syslog.L.Warn().WithField("verificationJobID", jobID).WithMessage("job not running, cannot stop").Write()
+						}
+					}
 					continue
 				}
 
@@ -126,6 +130,9 @@ func ExtJsVerificationRunHandler(storeInstance *store.Store) http.HandlerFunc {
 				go func(id string) {
 					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 					defer cancel()
+
+					verification.RegisterJob(id, cancel)
+					defer verification.UnregisterJob(id)
 
 					defer func() {
 						if vj.Cleanup != nil {

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -131,6 +131,51 @@ Ext.define("PBS.D2DVerification.JobPanel", {
       });
     },
 
+    stopJobs: function () {
+      var me = this;
+      var view = me.getView();
+      var recs = view.getSelection();
+      if (!recs.length) return;
+
+      var ids = recs.map(function (r) {
+        return r.getId();
+      });
+      var list = ids.map(Ext.String.htmlEncode).join("', '");
+
+      var msg =
+        ids.length > 1
+          ? Ext.String.format(
+              gettext("Stop verification jobs '{0}'?"),
+              list
+            )
+          : Ext.String.format(
+              gettext("Stop verification job '{0}'?"),
+              list
+            );
+
+      Ext.Msg.confirm(gettext("Confirm"), msg, function (btn) {
+        if (btn !== "yes") return;
+
+        var params = ids
+          .map(function (id) {
+            return "job=" + encodeURIComponent(encodePathValue(id));
+          })
+          .join("&");
+
+        PBS.PlusUtils.API2Request({
+          url: "/api2/extjs/d2d/verification?" + params,
+          method: "DELETE",
+          waitMsgTarget: view,
+          success: function () {
+            me.reload();
+          },
+          failure: function (resp) {
+            Ext.Msg.alert(gettext("Error"), resp.htmlStatus);
+          },
+        });
+      });
+    },
+
     showResults: function () {
       var me = this;
       var view = me.getView();
@@ -584,6 +629,23 @@ Ext.define("PBS.D2DVerification.JobPanel", {
       handler: "runJobs",
       enableFn: function () {
         return this.up("grid").getSelection().length > 0;
+      },
+      disabled: true,
+    },
+    {
+      xtype: "proxmoxButton",
+      text: gettext("Stop Job(s)"),
+      handler: "stopJobs",
+      enableFn: function () {
+        let recs = this.up("grid").getSelection();
+        return (
+          recs.length > 0 &&
+          recs.every((r) => {
+            const u = r.data["last-run-upid"];
+            const s = r.data["last-run-state"] || "";
+            return !!u && (s === "" || s.startsWith("QUEUED:"));
+          })
+        );
       },
       disabled: true,
     },

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -164,6 +164,8 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                 return '<span style="color:red;">\u2717 Failed</span>';
               case "skipped":
                 return '<span style="color:#888;">\u25CB Skipped</span>';
+              case "warning":
+                return '<span style="color:#c93;">\u26A0 Warning</span>';
               case "error":
                 return '<span style="color:#c43;">\u26A0 Error</span>';
               default:

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -824,7 +824,7 @@ Ext.define("PBS.D2DVerification.JobEdit", {
     me.method = id ? "PUT" : "POST";
     me.autoLoad = !!id;
     me.scheduleValue = id ? null : "";
-    me.modeValue = id ? null : "random_spot";
+    me.modeValue = "random_spot";
     return {};
   },
 

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -235,11 +235,11 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
           var backupCombo = panel.down("[reference=backupJobField]");
           var nsFields = panel.down("[reference=namespaceFields]");
           if (val === "namespace") {
-            if (backupCombo) backupCombo.hide();
-            if (nsFields) nsFields.show();
+            if (backupCombo) { backupCombo.hide(); backupCombo.disable(); }
+            if (nsFields) { nsFields.show(); nsFields.enable(); }
           } else {
-            if (backupCombo) backupCombo.show();
-            if (nsFields) nsFields.hide();
+            if (backupCombo) { backupCombo.show(); backupCombo.enable(); }
+            if (nsFields) { nsFields.hide(); nsFields.disable(); }
           }
         },
       },
@@ -266,6 +266,7 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
       reference: "namespaceFields",
       layout: "vbox",
       hidden: true,
+      disabled: true,
       width: "100%",
       items: [
         {


### PR DESCRIPTION
## Summary

- **TCP fork pattern**: Verification now forks an agent worker process (matching backup/restore patterns). The server sends a `verify_start` control message via QUIC, the agent forks itself, and the forked process connects back via TCP (StreamPipe) for all file hashing RPC calls.
- **Pre-stat check**: Agent `HashFile` now does `os.Stat` before opening, failing instantly on missing/non-regular files instead of potentially hanging on slow/network mounts.
- **Per-file timeout**: 5-minute timeout per `verify_chunk_file` call prevents stalling on slow reads.
- **Stop Job(s) button**: Added to the verification panel UI. Tracks active jobs with context cancellation for mid-run stop support.
- **`X-PBS-Plus-VerifyID` header**: Registered in `agents_manager` for TCP session identification.

## Commits (squashed from)
- `8f147a3c` perf(verification): parallel file verification with context awareness (#769)
- `d8d18fba` fix(verification): set default mode value on create for valid form
- `cd3d3ed4` fix(verification): disable hidden datastore selector for form validity
- `f9290126` feat(verification): TCP fork pattern, pre-stat check, job cancellation

## Test plan
- [ ] Create a verification job, run it, verify it completes
- [ ] Run a verification job, click Stop mid-way, verify it stops
- [ ] Verify the agent forks a child process that connects via TCP
- [ ] Verify pre-stat check returns fast for missing files