### PR TITLE
feat(verification): byte-based sampling

### DIFF
--- a/.github/actions/run-verification/action.yml
+++ b/.github/actions/run-verification/action.yml
@@ -11,20 +11,14 @@ runs:
   using: composite
   steps:
     # =====================================================================
-    # Helper: wait_for_verification_result
-    # Polls the results API until a new completed result appears.
-    # Args: $1=encoded_job_id $2=expected_min_results $3=timeout_secs
+    # Test Case 1: Basic spot check — small byte target
     # =====================================================================
-
-    # =====================================================================
-    # Test Case 1: Basic spot check with 5 files
-    # =====================================================================
-    - name: "[Case 1] Create and run basic verification job (5 files)"
+    - name: "[Case 1] Create and run basic verification job"
       shell: bash
       run: |
-        echo "=== Test Case 1: Basic spot check (5 files, use_latest=true) ==="
+        echo "=== Test Case 1: Basic spot check (small byte target, use_latest=true) ==="
 
-        # Create job
+        # Create job — 800 bytes should sample ~5 files (files are 16-256 bytes each)
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-basic" \
@@ -35,7 +29,7 @@ runs:
           -d "schedule=" \
           -d "retry=0" \
           -d "retry-interval=1" \
-          -d "sample_count=5" \
+          -d "sample_size=800" \
           -d "use_latest=true" \
           -d "comment=E2E basic spot check" \
           -w "\nHTTP_CODE:%{http_code}")
@@ -61,17 +55,21 @@ runs:
             total=$(echo "$response" | jq -r '.data[-1].total_files')
             verified=$(echo "$response" | jq -r '.data[-1].verified_files')
             failed=$(echo "$response" | jq -r '.data[-1].failed_files')
-            echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
+            sampled_bytes=$(echo "$response" | jq -r '.data[-1].sampled_bytes // 0')
+            echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}, Sampled bytes: ${sampled_bytes}"
 
             if [ "$failed" -gt 0 ]; then
               echo "✗ Case 1: ${failed} file(s) failed"
               echo "$response" | jq '.data[-1].details[] | select(.status != "ok")'
               exit 1
             fi
-            if [ "$total" -ne 5 ] || [ "$verified" -ne 5 ]; then
-              echo "✗ Case 1: Expected 5/5, got ${verified}/${total}"; exit 1
+            if [ "$total" -lt 3 ] || [ "$total" -gt 50 ]; then
+              echo "✗ Case 1: Unexpected file count ${total}"; exit 1
             fi
-            echo "✓ Case 1: PASSED (5/5 verified)"
+            if [ "$verified" -ne "$total" ]; then
+              echo "✗ Case 1: Not all files verified: ${verified}/${total}"; exit 1
+            fi
+            echo "✓ Case 1: PASSED (${verified}/${total} verified, ${sampled_bytes} bytes)"
             exit 0
           fi
           sleep 5
@@ -81,12 +79,12 @@ runs:
         exit 1
 
     # =====================================================================
-    # Test Case 2: Larger sample (20 files)
+    # Test Case 2: Larger byte target (~20 files worth)
     # =====================================================================
-    - name: "[Case 2] Create and run verification with 20 files"
+    - name: "[Case 2] Create and run verification with larger sample"
       shell: bash
       run: |
-        echo "=== Test Case 2: Larger sample (20 files) ==="
+        echo "=== Test Case 2: Larger sample (3000 bytes ≈ 20 files) ==="
 
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
@@ -98,7 +96,7 @@ runs:
           -d "schedule=" \
           -d "retry=0" \
           -d "retry-interval=1" \
-          -d "sample_count=20" \
+          -d "sample_size=3000" \
           -d "use_latest=true" \
           -d "comment=E2E large sample" \
           -w "\nHTTP_CODE:%{http_code}")
@@ -124,10 +122,10 @@ runs:
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
             if [ "$failed" -gt 0 ]; then echo "✗ Case 2: ${failed} failures"; exit 1; fi
-            if [ "$total" -ne 20 ] || [ "$verified" -ne 20 ]; then
-              echo "✗ Case 2: Expected 20/20, got ${verified}/${total}"; exit 1
+            if [ "$verified" -ne "$total" ]; then
+              echo "✗ Case 2: Not all verified: ${verified}/${total}"; exit 1
             fi
-            echo "✓ Case 2: PASSED (20/20 verified)"
+            echo "✓ Case 2: PASSED (${verified}/${total} verified)"
             exit 0
           fi
           sleep 5
@@ -135,13 +133,14 @@ runs:
         echo "✗ Case 2: Timed out"; exit 1
 
     # =====================================================================
-    # Test Case 3: Sample exceeds total files (request 100, expect all 50)
+    # Test Case 3: Sample exceeds total bytes (should get all 50 files)
     # =====================================================================
-    - name: "[Case 3] Sample exceeds total (100 requested, 50 exist)"
+    - name: "[Case 3] Sample exceeds total (request 1MB, all files ~7KB)"
       shell: bash
       run: |
-        echo "=== Test Case 3: Sample exceeds total files ==="
+        echo "=== Test Case 3: Sample exceeds total bytes ==="
 
+        # Request 1MB — total population is ~7KB so all files will be sampled
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-exceed" \
@@ -152,7 +151,7 @@ runs:
           -d "schedule=" \
           -d "retry=0" \
           -d "retry-interval=1" \
-          -d "sample_count=100" \
+          -d "sample_size=1048576" \
           -d "use_latest=true" \
           -d "comment=E2E sample exceeds total" \
           -w "\nHTTP_CODE:%{http_code}")
@@ -178,14 +177,14 @@ runs:
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
             if [ "$failed" -gt 0 ]; then echo "✗ Case 3: ${failed} failures"; exit 1; fi
-            # 50 test files exist; requesting 100 should cap at 50
+            # Should have all 50 files since we requested way more than total bytes
             if [ "$total" -ne 50 ]; then
               echo "✗ Case 3: Expected total=50 (capped), got ${total}"; exit 1
             fi
             if [ "$verified" -ne 50 ]; then
               echo "✗ Case 3: Expected verified=50, got ${verified}"; exit 1
             fi
-            echo "✓ Case 3: PASSED (50/50 verified, capped from 100)"
+            echo "✓ Case 3: PASSED (50/50 verified, capped from 1MB request)"
             exit 0
           fi
           sleep 5
@@ -225,8 +224,8 @@ runs:
             new_verified=$(echo "$response" | jq -r '.data[-1].verified_files')
             echo "  Results: ${before_count} → ${after_count}, Latest: ${new_verified}/${new_total} verified"
 
-            if [ "$new_total" -ne 5 ] || [ "$new_verified" -ne 5 ]; then
-              echo "✗ Case 4: Re-run results unexpected: ${new_verified}/${new_total}"; exit 1
+            if [ "$new_verified" -ne "$new_total" ]; then
+              echo "✗ Case 4: Re-run had failures: ${new_verified}/${new_total}"; exit 1
             fi
             echo "✓ Case 4: PASSED (${after_count} result sets, both completed)"
             exit 0
@@ -249,7 +248,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=5" \
+          -d "sample_size=800" \
           -d "use_latest=true" \
           -w "\nHTTP_CODE:%{http_code}")
         echo "Response: $response"
@@ -272,7 +271,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=5" \
+          -d "sample_size=800" \
           -d "use_latest=true" \
           -w "\nHTTP_CODE:%{http_code}")
         echo "Response: $response"
@@ -282,9 +281,9 @@ runs:
         echo "✓ Case 6: PASSED (correctly rejected)"
 
     # =====================================================================
-    # Test Case 7: Minimum sample (1 file)
+    # Test Case 7: Minimum sample (16 bytes = 1 file minimum)
     # =====================================================================
-    - name: "[Case 7] Create and run with sample_count=1"
+    - name: "[Case 7] Create and run with minimum sample size"
       shell: bash
       run: |
         echo "=== Test Case 7: Minimum sample (1 file) ==="
@@ -299,7 +298,7 @@ runs:
           -d "schedule=" \
           -d "retry=0" \
           -d "retry-interval=1" \
-          -d "sample_count=1" \
+          -d "sample_size=16" \
           -d "use_latest=true" \
           -d "comment=E2E minimum sample" \
           -w "\nHTTP_CODE:%{http_code}")
@@ -324,10 +323,14 @@ runs:
             failed=$(echo "$response" | jq -r '.data[-1].failed_files')
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
-            if [ "$total" -ne 1 ] || [ "$verified" -ne 1 ] || [ "$failed" -ne 0 ]; then
-              echo "✗ Case 7: Expected 1/1, got ${verified}/${total} (failed=${failed})"; exit 1
+            # 16 bytes should get at least 1 file
+            if [ "$total" -lt 1 ]; then
+              echo "✗ Case 7: Expected ≥1 files, got ${total}"; exit 1
             fi
-            echo "✓ Case 7: PASSED (1/1 verified)"
+            if [ "$failed" -ne 0 ]; then
+              echo "✗ Case 7: Failures found: ${failed}"; exit 1
+            fi
+            echo "✓ Case 7: PASSED (${verified}/${total} verified)"
             exit 0
           fi
           sleep 5
@@ -367,12 +370,12 @@ runs:
     - name: "[Case 9] Update job configuration"
       shell: bash
       run: |
-        echo "=== Test Case 9: Update job config (change sample_count 5→10) ==="
+        echo "=== Test Case 9: Update job config (change sample_size) ==="
         VERIFY_ID_ENCODED=$(echo -n "test-verify-basic" | base64 -w0)
 
         response=$(docker exec pbs-plus-test curl -s -k -X PUT "https://localhost:8017/api2/extjs/config/d2d-verification/${VERIFY_ID_ENCODED}" \
           -H "Content-Type: application/x-www-form-urlencoded" \
-          -d "sample_count=10" \
+          -d "sample_size=1500" \
           -d "comment=Updated E2E test" \
           -w "\nHTTP_CODE:%{http_code}")
         if ! echo "$response" | grep -q "HTTP_CODE:200"; then
@@ -382,15 +385,15 @@ runs:
         # Verify the update took effect
         job_response=$(docker exec pbs-plus-test curl -k -s "https://localhost:8017/api2/extjs/config/d2d-verification/${VERIFY_ID_ENCODED}" -H "Accept: application/json")
         comment=$(echo "$job_response" | jq -r '.data.comment')
-        sample_count=$(echo "$job_response" | jq -r '.data.spot_config.sample_count')
+        sample_size=$(echo "$job_response" | jq -r '.data.spot_config.sample_size')
 
         if [ "$comment" != "Updated E2E test" ]; then
           echo "✗ Case 9: Comment not updated (got: ${comment})"; exit 1
         fi
-        if [ "$sample_count" -ne 10 ]; then
-          echo "✗ Case 9: Sample count not updated (got: ${sample_count})"; exit 1
+        if [ "$sample_size" -ne 1500 ]; then
+          echo "✗ Case 9: Sample size not updated (got: ${sample_size})"; exit 1
         fi
-        echo "✓ Case 9: PASSED (sample_count=${sample_count}, comment=${comment})"
+        echo "✓ Case 9: PASSED (sample_size=${sample_size}, comment=${comment})"
 
     # =====================================================================
     # Test Case 10: Task log format verification
@@ -447,9 +450,9 @@ runs:
         id=$(echo "$response" | jq -r '.data.id')
         mode=$(echo "$response" | jq -r '.data.mode')
         backup_job_id=$(echo "$response" | jq -r '.data.backup_job_id')
-        sample_count=$(echo "$response" | jq -r '.data.spot_config.sample_count')
+        sample_size=$(echo "$response" | jq -r '.data.spot_config.sample_size')
 
-        echo "  ID: ${id}, Mode: ${mode}, BackupJob: ${backup_job_id}, SampleCount: ${sample_count}"
+        echo "  ID: ${id}, Mode: ${mode}, BackupJob: ${backup_job_id}, SampleSize: ${sample_size}"
 
         if [ "$id" != "test-verify-large" ]; then
           echo "✗ Case 11: Wrong job ID: ${id}"; exit 1
@@ -457,8 +460,8 @@ runs:
         if [ "$backup_job_id" != "test-backup-job" ]; then
           echo "✗ Case 11: Wrong backup_job_id: ${backup_job_id}"; exit 1
         fi
-        if [ "$sample_count" != "20" ]; then
-          echo "✗ Case 11: Wrong sample_count: ${sample_count}"; exit 1
+        if [ "$sample_size" != "3000" ]; then
+          echo "✗ Case 11: Wrong sample_size: ${sample_size}"; exit 1
         fi
         echo "✓ Case 11: PASSED"
 
@@ -501,6 +504,7 @@ runs:
         echo "=== Test Case 13: Path prefix filter ==="
 
         # Filter: path_pattern="/random1" matches /random1.txt, /random10.txt ... /random19.txt
+        # 11 matching files × ~136 bytes ≈ 1496 bytes — request enough to get all
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-path-prefix" \
@@ -508,7 +512,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=50" \
+          -d "sample_size=10000" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"path_pattern":"/random1"}]' \
           -d "comment=E2E path prefix filter" \
@@ -564,6 +568,7 @@ runs:
         echo "=== Test Case 14: Glob pattern filter ==="
 
         # Filter: path_pattern="*.txt" uses filepath.Match on basename
+        # Request 1500 bytes ≈ ~10 files
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-glob" \
@@ -571,7 +576,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=10" \
+          -d "sample_size=1500" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"path_pattern":"*.txt"}]' \
           -d "comment=E2E glob filter" \
@@ -598,9 +603,8 @@ runs:
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
             if [ "$failed" -gt 0 ]; then echo "✗ Case 14: ${failed} failures"; exit 1; fi
-            # All 50 test files are *.txt
-            if [ "$verified" -ne 10 ]; then
-              echo "✗ Case 14: Expected 10 verified, got ${verified}"; exit 1
+            if [ "$verified" -ne "$total" ]; then
+              echo "✗ Case 14: Not all verified: ${verified}/${total}"; exit 1
             fi
             echo "✓ Case 14: PASSED (${verified}/${total} verified, all *.txt)"
             exit 0
@@ -618,6 +622,7 @@ runs:
         echo "=== Test Case 15: Min size filter ==="
 
         # Filter: min_size=100 — files are 16-256 bytes, so this excludes small ones
+        # Request enough bytes to get all eligible files
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-min-size" \
@@ -625,7 +630,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=50" \
+          -d "sample_size=10000" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"min_size":100}]' \
           -d "comment=E2E min size filter" \
@@ -684,7 +689,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=50" \
+          -d "sample_size=10000" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"min_size":100,"max_size":200}]' \
           -d "comment=E2E size range filter" \
@@ -711,7 +716,6 @@ runs:
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
             if [ "$failed" -gt 0 ]; then echo "✗ Case 16: ${failed} failures"; exit 1; fi
-            # Fewer than the min_size=100 case (since max_size=200 further restricts)
             # All verified files must be 100-200 bytes
             out_of_range=$(echo "$response" | jq -r '.data[-1].details[] | select(.size < 100 or .size > 200) | .path' | head -5)
             if [ -n "$out_of_range" ]; then
@@ -742,7 +746,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=50" \
+          -d "sample_size=10000" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"path_pattern":"/random4"},{"min_size":200}]' \
           -d "comment=E2E multi OR filter" \
@@ -793,7 +797,6 @@ runs:
       run: |
         echo "=== Test Case 18: No matching files filter ==="
 
-        # Filter: path_pattern="/nonexistent/path" — nothing matches
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-no-match" \
@@ -801,7 +804,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=5" \
+          -d "sample_size=800" \
           -d "use_latest=true" \
           --data-urlencode 'filters=[{"path_pattern":"/nonexistent/path"}]' \
           -d "comment=E2E no match filter" \
@@ -839,13 +842,11 @@ runs:
       run: |
         echo "=== Test Case 19: Date range filter ==="
 
-        # Get today's date for the range
         TODAY=$(docker exec pbs-plus-test date -u +%Y-%m-%d)
         YESTERDAY=$(docker exec pbs-plus-test date -u -d "yesterday" +%Y-%m-%d)
         TOMORROW=$(docker exec pbs-plus-test date -u -d "tomorrow" +%Y-%m-%d)
         echo "  Date range: ${YESTERDAY} to ${TOMORROW}"
 
-        # use_latest=false with date range should pick a snapshot within range
         response=$(docker exec pbs-plus-test curl -s -k -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-date-range" \
@@ -853,7 +854,7 @@ runs:
           -d "store=test" \
           -d "ns=test" \
           -d "mode=spot-check" \
-          -d "sample_count=5" \
+          -d "sample_size=800" \
           -d "use_latest=false" \
           --data-urlencode "date_from=${YESTERDAY}" \
           --data-urlencode "date_to=${TOMORROW}" \
@@ -881,8 +882,8 @@ runs:
             echo "  Total: ${total}, Verified: ${verified}, Failed: ${failed}"
 
             if [ "$failed" -gt 0 ]; then echo "✗ Case 19: ${failed} failures"; exit 1; fi
-            if [ "$verified" -ne 5 ]; then
-              echo "✗ Case 19: Expected 5 verified, got ${verified}"; exit 1
+            if [ "$verified" -lt 1 ]; then
+              echo "✗ Case 19: Expected ≥1 verified, got ${verified}"; exit 1
             fi
             echo "✓ Case 19: PASSED (${verified}/${total} verified with date range)"
             exit 0
@@ -901,13 +902,14 @@ runs:
         set -eo pipefail
         echo "=== Test Case 20: Systematic sampling ==="
 
+        # 3000 bytes with systematic strategy
         response=$(docker exec pbs-plus-test curl -s -k -o /dev/null -w "%{http_code}" \
           -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-systematic" \
           -d "backup_job_id=test-backup-job" \
           -d "mode=random_spot" \
-          -d "spot_config={\"sample_count\":20,\"sampling_strategy\":\"systematic\",\"use_latest\":true}")
+          -d "spot_config={\"sample_size\":3000,\"sampling_strategy\":\"systematic\",\"use_latest\":true}")
         if [ "$response" != "200" ]; then
           echo "✗ Case 20: Create failed (HTTP ${response})"; exit 1
         fi
@@ -926,13 +928,13 @@ runs:
           if [ "$status" = "completed" ]; then
             verified=$(echo "$response" | jq -r '.data[-1].verified_files')
             population=$(echo "$response" | jq -r '.data[-1].total_population')
-            if [ "$verified" -ne 20 ]; then
-              echo "✗ Case 20: Expected 20 verified, got ${verified}"; exit 1
+            if [ "$verified" -lt 10 ]; then
+              echo "✗ Case 20: Expected ≥10 verified, got ${verified}"; exit 1
             fi
-            if [ "$population" -lt 20 ]; then
+            if [ "$population" -lt 1000 ]; then
               echo "✗ Case 20: total_population too low (${population})"; exit 1
             fi
-            echo "✓ Case 20: PASSED (${verified}/20 verified, population=${population}, systematic)"
+            echo "✓ Case 20: PASSED (${verified} verified, population=${population}, systematic)"
             exit 0
           fi
           sleep 5
@@ -945,13 +947,14 @@ runs:
         set -eo pipefail
         echo "=== Test Case 21: Stratified sampling ==="
 
+        # 5000 bytes with stratified strategy
         response=$(docker exec pbs-plus-test curl -s -k -o /dev/null -w "%{http_code}" \
           -X POST "https://localhost:8017/api2/extjs/config/d2d-verification" \
           -H "Content-Type: application/x-www-form-urlencoded" \
           -d "id=test-verify-stratified" \
           -d "backup_job_id=test-backup-job" \
           -d "mode=random_spot" \
-          -d "spot_config={\"sample_count\":30,\"sampling_strategy\":\"stratified\",\"use_latest\":true}")
+          -d "spot_config={\"sample_size\":5000,\"sampling_strategy\":\"stratified\",\"use_latest\":true}")
         if [ "$response" != "200" ]; then
           echo "✗ Case 21: Create failed (HTTP ${response})"; exit 1
         fi
@@ -969,10 +972,10 @@ runs:
           status=$(echo "$response" | jq -r '.data[-1].status // empty' 2>/dev/null)
           if [ "$status" = "completed" ]; then
             verified=$(echo "$response" | jq -r '.data[-1].verified_files')
-            if [ "$verified" -ne 30 ]; then
-              echo "✗ Case 21: Expected 30 verified, got ${verified}"; exit 1
+            if [ "$verified" -lt 20 ]; then
+              echo "✗ Case 21: Expected ≥20 verified, got ${verified}"; exit 1
             fi
-            echo "✓ Case 21: PASSED (${verified}/30 verified, stratified)"
+            echo "✓ Case 21: PASSED (${verified} verified, stratified)"
             exit 0
           fi
           sleep 5
@@ -985,12 +988,10 @@ runs:
         set -eo pipefail
         echo "=== Test Case 22: CSV detail export ==="
 
-        # Use the systematic job which was just created and verified in Case 20
         VERIFY_ID_ENCODED=$(echo -n "test-verify-systematic" | base64 -w0)
         response=$(docker exec pbs-plus-test curl -s -k \
           "https://localhost:8017/api2/extjs/config/d2d-verification/${VERIFY_ID_ENCODED}/results/export?type=detail")
 
-        # Check header row
         header=$(echo "$response" | head -1)
         if ! echo "$header" | grep -q "File Path"; then
           echo "✗ Case 22: Missing 'File Path' in header"
@@ -998,7 +999,6 @@ runs:
           exit 1
         fi
 
-        # Check data rows exist
         datalines=$(echo "$response" | tail -n +2 | grep -c "/random" || true)
         if [ "$datalines" -lt 1 ]; then
           echo "✗ Case 22: No data rows found"
@@ -1006,7 +1006,6 @@ runs:
           exit 1
         fi
 
-        # Check confidence columns present
         if ! echo "$header" | grep -q "Confidence 95%"; then
           echo "✗ Case 22: Missing confidence columns"
           exit 1
@@ -1031,7 +1030,6 @@ runs:
           exit 1
         fi
 
-        # Should have at least 1 summary row
         summary_rows=$(echo "$response" | tail -n +2 | grep -c "test-verify-systematic" || true)
         if [ "$summary_rows" -lt 1 ]; then
           echo "✗ Case 23: No summary rows"
@@ -1039,7 +1037,6 @@ runs:
           exit 1
         fi
 
-        # Check confidence values are present and reasonable
         first_data=$(echo "$response" | head -2 | tail -1)
         conf95=$(echo "$first_data" | awk -F',' '{print $10}')
         if [ -z "$conf95" ]; then
@@ -1056,68 +1053,35 @@ runs:
         set -eo pipefail
         echo "=== Test Case 24: Confidence data in API results ==="
 
-        # Check that total_population is populated in a result
         VERIFY_ID_ENCODED=$(echo -n "test-verify-systematic" | base64 -w0)
         response=$(docker exec pbs-plus-test curl -s -k \
           "https://localhost:8017/api2/extjs/config/d2d-verification/${VERIFY_ID_ENCODED}/results")
 
         population=$(echo "$response" | jq -r '.data[-1].total_population // empty')
-        sampled=$(echo "$response" | jq -r '.data[-1].total_files')
-        verified=$(echo "$response" | jq -r '.data[-1].verified_files')
+        total_files=$(echo "$response" | jq -r '.data[-1].total_files')
+        sampled_bytes=$(echo "$response" | jq -r '.data[-1].sampled_bytes // 0')
+        failed=$(echo "$response" | jq -r '.data[-1].failed_files')
+        failed_bytes=$(echo "$response" | jq -r '.data[-1].failed_bytes // 0')
 
-        if [ -z "$population" ] || [ "$population" -le 0 ]; then
-          echo "✗ Case 24: total_population missing or zero (${population})"
-          exit 1
+        echo "  Population: ${population}, Sampled bytes: ${sampled_bytes}, Files: ${total_files}"
+        echo "  Failed: ${failed}, Failed bytes: ${failed_bytes}"
+
+        if [ -z "$population" ] || [ "$population" = "null" ] || [ "$population" -le 0 ]; then
+          echo "✗ Case 24: total_population not populated"; exit 1
         fi
 
-        if [ "$population" -lt "$sampled" ]; then
-          echo "✗ Case 24: population (${population}) < sampled (${sampled})"
-          exit 1
+        if [ -z "$sampled_bytes" ] || [ "$sampled_bytes" = "null" ] || [ "$sampled_bytes" -le 0 ]; then
+          echo "✗ Case 24: sampled_bytes not populated"; exit 1
         fi
 
-        # Population should be 50 (50 test files)
-        if [ "$population" -ne 50 ]; then
-          echo "✗ Case 24: Expected population 50, got ${population}"
-          exit 1
+        if [ "$total_files" -le 0 ]; then
+          echo "✗ Case 24: total_files not populated"; exit 1
         fi
 
-        echo "  Population: ${population}, Sampled: ${sampled}, Verified: ${verified}"
-        echo "✓ Case 24: PASSED (population=${population}, sample=${sampled}, verified=${verified})"
+        if [ "$failed" -gt 0 ]; then
+          if [ "$failed_bytes" -le 0 ]; then
+            echo "✗ Case 24: failed_files > 0 but failed_bytes = 0"; exit 1
+          fi
+        fi
 
-    # =====================================================================
-    # Summary
-    # =====================================================================
-    - name: Verification test summary
-      shell: bash
-      run: |
-        echo ""
-        echo "============================================"
-        echo "  Verification E2E Test Results"
-        echo "============================================"
-        echo "  Case  1: Basic spot check (5 files)       ✓"
-        echo "  Case  2: Larger sample (20 files)          ✓"
-        echo "  Case  3: Sample exceeds total (100→50)     ✓"
-        echo "  Case  4: Re-run existing job               ✓"
-        echo "  Case  5: Duplicate job ID (reject)         ✓"
-        echo "  Case  6: Nonexistent backup (reject)       ✓"
-        echo "  Case  7: Minimum sample (1 file)           ✓"
-        echo "  Case  8: List all jobs                     ✓"
-        echo "  Case  9: Update job configuration          ✓"
-        echo "  Case 10: Task log format (UPID/history)    ✓"
-        echo "  Case 11: Get single job by ID              ✓"
-        echo "  Case 12: Delete job                         ✓"
-        echo "  Case 13: Path prefix filter (/random1)     ✓"
-        echo "  Case 14: Glob pattern filter (*.txt)        ✓"
-        echo "  Case 15: Min size filter (≥100 bytes)      ✓"
-        echo "  Case 16: Size range filter (100-200 bytes)  ✓"
-        echo "  Case 17: Multiple OR filters               ✓"
-        echo "  Case 18: No-match filter (graceful fail)   ✓"
-        echo "  Case 19: Date range (use_latest=false)     ✓"
-        echo "  Case 20: Systematic sampling strategy      ✓"
-        echo "  Case 21: Stratified sampling strategy      ✓"
-        echo "  Case 22: CSV export (detail)               ✓"
-        echo "  Case 23: CSV export (summary)              ✓"
-        echo "  Case 24: Total population + confidence     ✓"
-        echo "============================================"
-        echo "  All 24 test cases PASSED"
-        echo "============================================"
+        echo "✓ Case 24: PASSED (all byte-based metrics populated)"

--- a/internal/server/database/migrations/000029_add_sampled_failed_bytes.down.sql
+++ b/internal/server/database/migrations/000029_add_sampled_failed_bytes.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE verification_results DROP COLUMN failed_bytes;
+ALTER TABLE verification_results DROP COLUMN sampled_bytes;

--- a/internal/server/database/migrations/000029_add_sampled_failed_bytes.up.sql
+++ b/internal/server/database/migrations/000029_add_sampled_failed_bytes.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE verification_results ADD COLUMN sampled_bytes INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE verification_results ADD COLUMN failed_bytes INTEGER NOT NULL DEFAULT 0;

--- a/internal/server/database/queries/verification_jobs.sql
+++ b/internal/server/database/queries/verification_jobs.sql
@@ -37,8 +37,9 @@ SELECT 1 FROM verification_jobs WHERE id = ? LIMIT 1;
 INSERT INTO verification_results (
     verification_job_id, upid, snapshot, snapshot_time,
     total_files, verified_files, failed_files, skipped_files,
+    sampled_bytes, failed_bytes,
     status, started_at, completed_at, details, total_population
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetVerificationResults :many
 SELECT *
@@ -56,7 +57,8 @@ LIMIT 1;
 -- name: UpdateVerificationResult :exec
 UPDATE verification_results
 SET upid = ?, total_files = ?, verified_files = ?, failed_files = ?,
-    skipped_files = ?, status = ?, completed_at = ?, details = ?,
+    skipped_files = ?, sampled_bytes = ?, failed_bytes = ?,
+    status = ?, completed_at = ?, details = ?,
     total_population = ?
 WHERE id = ?;
 

--- a/internal/server/database/sqlc/models.go
+++ b/internal/server/database/sqlc/models.go
@@ -140,4 +140,6 @@ type VerificationResult struct {
 	CompletedAt       sql.NullInt64  `json:"completed_at"`
 	Details           sql.NullString `json:"details"`
 	TotalPopulation   int64          `json:"total_population"`
+	SampledBytes      int64          `json:"sampled_bytes"`
+	FailedBytes       int64          `json:"failed_bytes"`
 }

--- a/internal/server/database/sqlc/verification_jobs.sql.go
+++ b/internal/server/database/sqlc/verification_jobs.sql.go
@@ -71,8 +71,9 @@ const createVerificationResult = `-- name: CreateVerificationResult :execresult
 INSERT INTO verification_results (
     verification_job_id, upid, snapshot, snapshot_time,
     total_files, verified_files, failed_files, skipped_files,
+    sampled_bytes, failed_bytes,
     status, started_at, completed_at, details, total_population
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type CreateVerificationResultParams struct {
@@ -84,6 +85,8 @@ type CreateVerificationResultParams struct {
 	VerifiedFiles     sql.NullInt64  `json:"verified_files"`
 	FailedFiles       sql.NullInt64  `json:"failed_files"`
 	SkippedFiles      sql.NullInt64  `json:"skipped_files"`
+	SampledBytes      int64          `json:"sampled_bytes"`
+	FailedBytes       int64          `json:"failed_bytes"`
 	Status            sql.NullString `json:"status"`
 	StartedAt         sql.NullInt64  `json:"started_at"`
 	CompletedAt       sql.NullInt64  `json:"completed_at"`
@@ -101,6 +104,8 @@ func (q *Queries) CreateVerificationResult(ctx context.Context, arg CreateVerifi
 		arg.VerifiedFiles,
 		arg.FailedFiles,
 		arg.SkippedFiles,
+		arg.SampledBytes,
+		arg.FailedBytes,
 		arg.Status,
 		arg.StartedAt,
 		arg.CompletedAt,
@@ -134,7 +139,7 @@ func (q *Queries) DeleteVerificationResults(ctx context.Context, verificationJob
 }
 
 const getLatestVerificationResult = `-- name: GetLatestVerificationResult :one
-SELECT id, verification_job_id, upid, snapshot, snapshot_time, total_files, verified_files, failed_files, skipped_files, status, started_at, completed_at, details, total_population
+SELECT id, verification_job_id, upid, snapshot, snapshot_time, total_files, verified_files, failed_files, skipped_files, status, started_at, completed_at, details, total_population, sampled_bytes, failed_bytes
 FROM verification_results
 WHERE verification_job_id = ?
 ORDER BY started_at DESC
@@ -159,6 +164,8 @@ func (q *Queries) GetLatestVerificationResult(ctx context.Context, verificationJ
 		&i.CompletedAt,
 		&i.Details,
 		&i.TotalPopulation,
+		&i.SampledBytes,
+		&i.FailedBytes,
 	)
 	return i, err
 }
@@ -201,7 +208,7 @@ func (q *Queries) GetVerificationJob(ctx context.Context, id string) (Verificati
 }
 
 const getVerificationResults = `-- name: GetVerificationResults :many
-SELECT id, verification_job_id, upid, snapshot, snapshot_time, total_files, verified_files, failed_files, skipped_files, status, started_at, completed_at, details, total_population
+SELECT id, verification_job_id, upid, snapshot, snapshot_time, total_files, verified_files, failed_files, skipped_files, status, started_at, completed_at, details, total_population, sampled_bytes, failed_bytes
 FROM verification_results
 WHERE verification_job_id = ?
 ORDER BY started_at DESC
@@ -231,6 +238,8 @@ func (q *Queries) GetVerificationResults(ctx context.Context, verificationJobID 
 			&i.CompletedAt,
 			&i.Details,
 			&i.TotalPopulation,
+			&i.SampledBytes,
+			&i.FailedBytes,
 		); err != nil {
 			return nil, err
 		}
@@ -374,7 +383,8 @@ func (q *Queries) UpdateVerificationJob(ctx context.Context, arg UpdateVerificat
 const updateVerificationResult = `-- name: UpdateVerificationResult :exec
 UPDATE verification_results
 SET upid = ?, total_files = ?, verified_files = ?, failed_files = ?,
-    skipped_files = ?, status = ?, completed_at = ?, details = ?,
+    skipped_files = ?, sampled_bytes = ?, failed_bytes = ?,
+    status = ?, completed_at = ?, details = ?,
     total_population = ?
 WHERE id = ?
 `
@@ -385,6 +395,8 @@ type UpdateVerificationResultParams struct {
 	VerifiedFiles   sql.NullInt64  `json:"verified_files"`
 	FailedFiles     sql.NullInt64  `json:"failed_files"`
 	SkippedFiles    sql.NullInt64  `json:"skipped_files"`
+	SampledBytes    int64          `json:"sampled_bytes"`
+	FailedBytes     int64          `json:"failed_bytes"`
 	Status          sql.NullString `json:"status"`
 	CompletedAt     sql.NullInt64  `json:"completed_at"`
 	Details         sql.NullString `json:"details"`
@@ -399,6 +411,8 @@ func (q *Queries) UpdateVerificationResult(ctx context.Context, arg UpdateVerifi
 		arg.VerifiedFiles,
 		arg.FailedFiles,
 		arg.SkippedFiles,
+		arg.SampledBytes,
+		arg.FailedBytes,
 		arg.Status,
 		arg.CompletedAt,
 		arg.Details,

--- a/internal/server/database/types.go
+++ b/internal/server/database/types.go
@@ -264,14 +264,14 @@ type VerificationJob struct {
 
 // SpotCheckConfig holds configuration for random spot check mode.
 type SpotCheckConfig struct {
-	SampleCount        int               `json:"sample_count"`
-	SampleCountPercent float64           `json:"sample_count_percent"` // 0–100, used when > 0
-	SamplingStrategy   string            `json:"sampling_strategy"`    // random, systematic, stratified
-	UseLatest          bool              `json:"use_latest"`
-	DateFrom           string            `json:"date_from"` // RFC3339 or empty
-	DateTo             string            `json:"date_to"`   // RFC3339 or empty
-	Filters            []SpotCheckFilter `json:"filters"`
-	FailThreshold      int               `json:"fail_threshold"` // stop after N failures (0 = no limit)
+	SampleSize        int64             `json:"sample_size"`         // target total bytes to sample
+	SampleSizePercent float64           `json:"sample_size_percent"` // 0–100 percentage of population bytes
+	SamplingStrategy  string            `json:"sampling_strategy"`   // random, systematic, stratified
+	UseLatest         bool              `json:"use_latest"`
+	DateFrom          string            `json:"date_from"` // RFC3339 or empty
+	DateTo            string            `json:"date_to"`   // RFC3339 or empty
+	Filters           []SpotCheckFilter `json:"filters"`
+	FailThreshold     int               `json:"fail_threshold"` // stop after N failures (0 = no limit)
 }
 
 // SpotCheckFilter defines a filter for selecting files in spot checks.
@@ -288,10 +288,12 @@ type VerificationResult struct {
 	UPID              string                   `json:"upid"`
 	Snapshot          string                   `json:"snapshot"`
 	SnapshotTime      int64                    `json:"snapshot_time"`
-	TotalPopulation   int                      `json:"total_population"` // total eligible files in archive
+	TotalPopulation   int64                    `json:"total_population"` // total eligible bytes in archive
 	TotalFiles        int                      `json:"total_files"`      // files actually sampled
+	SampledBytes      int64                    `json:"sampled_bytes"`    // total bytes in sampled files
 	VerifiedFiles     int                      `json:"verified_files"`
 	FailedFiles       int                      `json:"failed_files"`
+	FailedBytes       int64                    `json:"failed_bytes"` // total bytes in failed files
 	SkippedFiles      int                      `json:"skipped_files"`
 	Status            string                   `json:"status"` // pending, running, completed, failed
 	StartedAt         int64                    `json:"started_at"`

--- a/internal/server/database/verification_jobs.go
+++ b/internal/server/database/verification_jobs.go
@@ -105,8 +105,8 @@ func (database *Database) CreateVerificationJob(tx *Transaction, job Verificatio
 	if job.Mode == "" {
 		job.Mode = "random_spot"
 	}
-	if job.SpotConfig.SampleCount <= 0 && job.SpotConfig.SampleCountPercent <= 0 {
-		job.SpotConfig.SampleCount = 10
+	if job.SpotConfig.SampleSize <= 0 && job.SpotConfig.SampleSizePercent <= 0 {
+		job.SpotConfig.SampleSize = 1 << 30 // 1 GiB default
 	}
 
 	spotConfigJSON, err := json.Marshal(job.SpotConfig)
@@ -447,11 +447,13 @@ func (database *Database) CreateVerificationResult(result *VerificationResult) e
 		VerifiedFiles:     toNullInt64(result.VerifiedFiles),
 		FailedFiles:       toNullInt64(result.FailedFiles),
 		SkippedFiles:      toNullInt64(result.SkippedFiles),
+		SampledBytes:      result.SampledBytes,
+		FailedBytes:       result.FailedBytes,
 		Status:            toNullString(result.Status),
 		StartedAt:         toNullInt64(int(result.StartedAt)),
 		CompletedAt:       toNullInt64(int(result.CompletedAt)),
 		Details:           toNullString(string(detailsJSON)),
-		TotalPopulation:   int64(result.TotalPopulation),
+		TotalPopulation:   result.TotalPopulation,
 	})
 	if err != nil {
 		return fmt.Errorf("CreateVerificationResult: error inserting: %w", err)
@@ -478,10 +480,12 @@ func (database *Database) UpdateVerificationResult(result VerificationResult) er
 		VerifiedFiles:   toNullInt64(result.VerifiedFiles),
 		FailedFiles:     toNullInt64(result.FailedFiles),
 		SkippedFiles:    toNullInt64(result.SkippedFiles),
+		SampledBytes:    result.SampledBytes,
+		FailedBytes:     result.FailedBytes,
 		Status:          toNullString(result.Status),
 		CompletedAt:     toNullInt64(int(result.CompletedAt)),
 		Details:         toNullString(string(detailsJSON)),
-		TotalPopulation: int64(result.TotalPopulation),
+		TotalPopulation: result.TotalPopulation,
 		ID:              int64(result.ID),
 	})
 }
@@ -512,10 +516,12 @@ func (database *Database) GetVerificationResults(jobID string) ([]VerificationRe
 			VerifiedFiles:     fromNullInt64(row.VerifiedFiles),
 			FailedFiles:       fromNullInt64(row.FailedFiles),
 			SkippedFiles:      fromNullInt64(row.SkippedFiles),
+			SampledBytes:      row.SampledBytes,
+			FailedBytes:       row.FailedBytes,
 			Status:            fromNullString(row.Status),
 			StartedAt:         int64(fromNullInt64(row.StartedAt)),
 			CompletedAt:       int64(fromNullInt64(row.CompletedAt)),
-			TotalPopulation:   int(row.TotalPopulation),
+			TotalPopulation:   row.TotalPopulation,
 		}
 
 		if detailsStr := fromNullString(row.Details); detailsStr != "" {
@@ -549,10 +555,12 @@ func (database *Database) GetLatestVerificationResult(jobID string) (Verificatio
 		VerifiedFiles:     fromNullInt64(row.VerifiedFiles),
 		FailedFiles:       fromNullInt64(row.FailedFiles),
 		SkippedFiles:      fromNullInt64(row.SkippedFiles),
+		SampledBytes:      row.SampledBytes,
+		FailedBytes:       row.FailedBytes,
 		Status:            fromNullString(row.Status),
 		StartedAt:         int64(fromNullInt64(row.StartedAt)),
 		CompletedAt:       int64(fromNullInt64(row.CompletedAt)),
-		TotalPopulation:   int(row.TotalPopulation),
+		TotalPopulation:   row.TotalPopulation,
 	}
 
 	if detailsStr := fromNullString(row.Details); detailsStr != "" {

--- a/internal/server/verification/job.go
+++ b/internal/server/verification/job.go
@@ -129,7 +129,7 @@ type verificationJob struct {
 	skippedFiles    int
 	totalFiles      int
 	resultID        int
-	totalPopulation int
+	totalPopulation int64 // total eligible bytes
 }
 
 // NewVerificationJob creates a new verification job.
@@ -397,6 +397,9 @@ func (v *verificationJob) executeVerification(
 	}
 
 	result.TotalFiles = len(sampledFiles)
+	for _, f := range sampledFiles {
+		result.SampledBytes += f.Size
+	}
 	v.mu.RLock()
 	result.TotalPopulation = v.totalPopulation
 	v.mu.RUnlock()
@@ -468,6 +471,7 @@ func (v *verificationJob) executeVerification(
 			result.VerifiedFiles++
 		case "failed":
 			result.FailedFiles++
+			result.FailedBytes += ir.result.Size
 			vTask.WriteString(fmt.Sprintf("file verification failed: %s - %s", ir.result.Path, ir.result.Message))
 		default:
 			result.SkippedFiles++
@@ -871,20 +875,25 @@ func (v *verificationJob) sampleFiles(ctx context.Context, job database.Verifica
 		return nil, ErrNoFilesToVerify
 	}
 
-	// Store total population for confidence calculation
+	var totalBytes int64
+	for _, f := range allFiles {
+		totalBytes += f.Size
+	}
+
+	// Store total population (bytes) and file count for confidence calculation
 	v.mu.Lock()
-	v.totalPopulation = len(allFiles)
+	v.totalPopulation = totalBytes
 	v.mu.Unlock()
 
-	sampleCount := job.SpotConfig.SampleCount
-	if job.SpotConfig.SampleCountPercent > 0 {
-		sampleCount = int(math.Ceil(float64(len(allFiles)) * job.SpotConfig.SampleCountPercent / 100))
+	targetSize := job.SpotConfig.SampleSize
+	if job.SpotConfig.SampleSizePercent > 0 {
+		targetSize = int64(math.Ceil(float64(totalBytes) * job.SpotConfig.SampleSizePercent / 100))
 	}
-	if sampleCount <= 0 {
-		sampleCount = 10
+	if targetSize <= 0 {
+		targetSize = 1 << 30 // 1 GiB default
 	}
-	if sampleCount > len(allFiles) {
-		sampleCount = len(allFiles)
+	if targetSize > totalBytes {
+		targetSize = totalBytes
 	}
 
 	strategy := job.SpotConfig.SamplingStrategy
@@ -894,78 +903,117 @@ func (v *verificationJob) sampleFiles(ctx context.Context, job database.Verifica
 
 	switch strategy {
 	case "systematic":
-		return systematicSample(allFiles, sampleCount), nil
+		return systematicSampleBySize(allFiles, targetSize), nil
 	case "stratified":
-		return stratifiedSample(allFiles, sampleCount), nil
+		return stratifiedSampleBySize(allFiles, targetSize), nil
 	default: // random
 		rand.Shuffle(len(allFiles), func(i, j int) {
 			allFiles[i], allFiles[j] = allFiles[j], allFiles[i]
 		})
-		return allFiles[:sampleCount], nil
+		return accumulateBySize(allFiles, targetSize), nil
 	}
 }
 
 // systematicSample takes every k-th file after sorting by path for even coverage.
-func systematicSample(files []fileEntry, n int) []fileEntry {
+// accumulateBySize accumulates files from the list until total bytes reaches target.
+// The input list should already be ordered (shuffled/sorted) by the caller.
+func accumulateBySize(files []fileEntry, targetBytes int64) []fileEntry {
+	var accumulated int64
+	for i, f := range files {
+		if accumulated >= targetBytes {
+			return files[:i]
+		}
+		accumulated += f.Size
+	}
+	return files
+}
+
+// systematicSampleBySize sorts files by path and picks every k-th file until
+// accumulated bytes reach the target.
+func systematicSampleBySize(files []fileEntry, targetBytes int64) []fileEntry {
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Path < files[j].Path
 	})
 
-	if n >= len(files) {
+	var totalBytes int64
+	for _, f := range files {
+		totalBytes += f.Size
+	}
+	if totalBytes <= targetBytes {
 		return files
 	}
 
-	result := make([]fileEntry, n)
-	step := float64(len(files)) / float64(n)
-	for i := range n {
-		idx := int(float64(i) * step)
-		result[i] = files[idx]
+	// Estimate step so accumulated bytes ≈ targetBytes
+	step := float64(len(files)) / float64(targetBytes) * (float64(totalBytes) / float64(len(files)))
+	if step < 1 {
+		step = 1
+	}
+
+	var result []fileEntry
+	var accumulated int64
+	idx := 0.0
+	for int(idx) < len(files) && accumulated < targetBytes {
+		f := files[int(idx)]
+		result = append(result, f)
+		accumulated += f.Size
+		idx += step
 	}
 	return result
 }
 
-// stratifiedSample groups files by top-level directory and samples
-// proportionally from each group.
-func stratifiedSample(files []fileEntry, n int) []fileEntry {
-	if n >= len(files) {
+// stratifiedSampleBySize groups files by top-level directory and samples
+// proportionally by byte size from each group.
+func stratifiedSampleBySize(files []fileEntry, targetBytes int64) []fileEntry {
+	var totalBytes int64
+	for _, f := range files {
+		totalBytes += f.Size
+	}
+	if totalBytes <= targetBytes {
 		return files
 	}
 
-	// Group by top-level directory
-	groups := make(map[string][]fileEntry)
+	// Group by top-level directory and compute per-group byte totals
+	type groupInfo struct {
+		files []fileEntry
+		bytes int64
+	}
+	groups := make(map[string]*groupInfo)
+	var groupOrder []string
 	for _, f := range files {
 		dir := topLevelDir(f.Path)
-		groups[dir] = append(groups[dir], f)
+		if _, ok := groups[dir]; !ok {
+			groups[dir] = &groupInfo{}
+			groupOrder = append(groupOrder, dir)
+		}
+		groups[dir].files = append(groups[dir].files, f)
+		groups[dir].bytes += f.Size
 	}
+	sort.Strings(groupOrder)
 
 	var result []fileEntry
-	remaining := n
-	groupNames := make([]string, 0, len(groups))
-	for k := range groups {
-		groupNames = append(groupNames, k)
-	}
-	sort.Strings(groupNames)
-
-	for i, name := range groupNames {
+	remaining := targetBytes
+	for i, name := range groupOrder {
 		g := groups[name]
-		// Proportional allocation
-		var allocated int
-		if i == len(groupNames)-1 {
-			allocated = remaining // last group gets remainder
+		var allocBytes int64
+		if i == len(groupOrder)-1 {
+			allocBytes = remaining // last group gets remainder
 		} else {
-			allocated = min(int(math.Round(float64(len(g))/float64(len(files))*float64(n))), remaining)
+			allocBytes = min(int64(math.Round(float64(g.bytes)/float64(totalBytes)*float64(targetBytes))), remaining)
 		}
 
-		if allocated > len(g) {
-			allocated = len(g)
-		}
-
-		rand.Shuffle(len(g), func(i, j int) {
-			g[i], g[j] = g[j], g[i]
+		// Shuffle within group, then accumulate until allocBytes reached
+		rand.Shuffle(len(g.files), func(i, j int) {
+			g.files[i], g.files[j] = g.files[j], g.files[i]
 		})
-
-		result = append(result, g[:allocated]...)
-		remaining -= allocated
+		var acc int64
+		for _, f := range g.files {
+			if acc >= allocBytes {
+				break
+			}
+			result = append(result, f)
+			acc += f.Size
+		}
+		remaining -= acc
 	}
 
 	return result

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -207,17 +207,17 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 			}
 		}
 
-		sampleCount := 10
-		if sc := r.FormValue("sample_count"); sc != "" {
-			if n, err := strconv.Atoi(sc); err == nil && n > 0 {
-				sampleCount = n
+		sampleSize := int64(1 << 30) // 1 GiB default
+		if ss := r.FormValue("sample_size"); ss != "" {
+			if n, err := strconv.ParseInt(ss, 10, 64); err == nil && n > 0 {
+				sampleSize = n
 			}
 		}
 
-		var sampleCountPercent float64
-		if scp := r.FormValue("sample_count_percent"); scp != "" {
-			if v, err := strconv.ParseFloat(scp, 64); err == nil && v > 0 {
-				sampleCountPercent = v
+		var sampleSizePercent float64
+		if ssp := r.FormValue("sample_size_percent"); ssp != "" {
+			if v, err := strconv.ParseFloat(ssp, 64); err == nil && v > 0 {
+				sampleSizePercent = v
 			}
 		}
 
@@ -273,13 +273,13 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 			Retry:         retry,
 			RetryInterval: retryInterval,
 			SpotConfig: database.SpotCheckConfig{
-				SampleCount:        sampleCount,
-				SampleCountPercent: sampleCountPercent,
-				SamplingStrategy:   r.FormValue("sampling_strategy"),
-				UseLatest:          useLatest,
-				DateFrom:           r.FormValue("date_from"),
-				DateTo:             r.FormValue("date_to"),
-				FailThreshold:      failThreshold,
+				SampleSize:        sampleSize,
+				SampleSizePercent: sampleSizePercent,
+				SamplingStrategy:  r.FormValue("sampling_strategy"),
+				UseLatest:         useLatest,
+				DateFrom:          r.FormValue("date_from"),
+				DateTo:            r.FormValue("date_to"),
+				FailThreshold:     failThreshold,
 			},
 			RunOnBackupComplete: r.FormValue("run_on_backup_complete") == "true",
 		}
@@ -295,8 +295,8 @@ func ExtJsVerificationConfigHandler(storeInstance *store.Store) http.HandlerFunc
 		if spotConfigJSON := r.FormValue("spot_config"); spotConfigJSON != "" {
 			var sc database.SpotCheckConfig
 			if err := json.Unmarshal([]byte(spotConfigJSON), &sc); err == nil {
-				if sc.SampleCount > 0 {
-					job.SpotConfig.SampleCount = sc.SampleCount
+				if sc.SampleSize > 0 {
+					job.SpotConfig.SampleSize = sc.SampleSize
 				}
 				if sc.SamplingStrategy != "" {
 					job.SpotConfig.SamplingStrategy = sc.SamplingStrategy
@@ -422,14 +422,14 @@ func ExtJsVerificationConfigSingleHandler(storeInstance *store.Store) http.Handl
 				job.RetryInterval = retryInterval
 			}
 
-			if sc := r.FormValue("sample_count"); sc != "" {
-				if n, err := strconv.Atoi(sc); err == nil && n > 0 {
-					job.SpotConfig.SampleCount = n
+			if ss := r.FormValue("sample_size"); ss != "" {
+				if n, err := strconv.ParseInt(ss, 10, 64); err == nil && n > 0 {
+					job.SpotConfig.SampleSize = n
 				}
 			}
-			if scp := r.FormValue("sample_count_percent"); scp != "" {
-				if v, err := strconv.ParseFloat(scp, 64); err == nil && v > 0 {
-					job.SpotConfig.SampleCountPercent = v
+			if ssp := r.FormValue("sample_size_percent"); ssp != "" {
+				if v, err := strconv.ParseFloat(ssp, 64); err == nil && v > 0 {
+					job.SpotConfig.SampleSizePercent = v
 				}
 			}
 			if ss := r.FormValue("sampling_strategy"); ss != "" {
@@ -568,14 +568,14 @@ func writeSummaryCSV(w http.ResponseWriter, results []database.VerificationResul
 	for _, r := range results {
 		startedAt := formatTimestamp(r.StartedAt)
 		completedAt := formatTimestamp(r.CompletedAt)
-		conf95, conf99 := computeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
+		conf95, conf99 := computeConfidence(r.TotalPopulation, r.SampledBytes, r.FailedBytes)
 		fmt.Fprintf(w, "%s,%d,%s,%s,%d,%d,%d,%d,%d,%.1f%%,%.1f%%,%s,%s\n",
 			csvEscape(r.VerificationJobID),
 			r.ID,
 			csvEscape(r.Snapshot),
 			r.Status,
 			r.TotalPopulation,
-			r.TotalFiles,
+			r.SampledBytes,
 			r.VerifiedFiles,
 			r.FailedFiles,
 			r.SkippedFiles,
@@ -590,14 +590,14 @@ func writeSummaryCSV(w http.ResponseWriter, results []database.VerificationResul
 func writeDetailCSV(w http.ResponseWriter, results []database.VerificationResult) {
 	fmt.Fprintln(w, "Job ID,Run ID,Snapshot,Total Population,Sample Size,File Path,File Size,Status,Message,Confidence 95%,Confidence 99%")
 	for _, r := range results {
-		conf95, conf99 := computeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
+		conf95, conf99 := computeConfidence(r.TotalPopulation, r.SampledBytes, r.FailedBytes)
 		for _, f := range r.Details {
 			fmt.Fprintf(w, "%s,%d,%s,%d,%d,%s,%d,%s,%s,%.1f%%,%.1f%%\n",
 				csvEscape(r.VerificationJobID),
 				r.ID,
 				csvEscape(r.Snapshot),
 				r.TotalPopulation,
-				r.TotalFiles,
+				r.SampledBytes,
 				csvEscape(f.Path),
 				f.Size,
 				f.Status,
@@ -610,21 +610,22 @@ func writeDetailCSV(w http.ResponseWriter, results []database.VerificationResult
 }
 
 // computeConfidence returns the lower bound of the intact rate at 95% and 99% confidence.
+// Uses byte-based population, sample, and failure counts for data integrity metrics.
 // Uses the Rule of Three for zero-failure samples and the Wilson score interval otherwise.
-func computeConfidence(population, sample, failures int) (float64, float64) {
-	if sample <= 0 || failures >= sample {
+func computeConfidence(populationBytes, sampledBytes, failedBytes int64) (float64, float64) {
+	if sampledBytes <= 0 || failedBytes >= sampledBytes {
 		return 0, 0
 	}
 
-	n := float64(sample)
-	N := float64(population)
+	n := float64(sampledBytes)
+	N := float64(populationBytes)
 	if N <= 0 || n > N {
 		N = n
 	}
 
-	fHat := float64(failures) / n
+	fHat := float64(failedBytes) / n
 
-	if failures == 0 {
+	if failedBytes == 0 {
 		// Rule of Three with finite population correction
 		fpc := math.Sqrt((N - n) / N)
 		if fpc < 0 {

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -254,12 +254,12 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             );
           }
 
-          function computeConfidence(population, sample, failures) {
-            if (sample <= 0 || failures >= sample) return { c95: 0, c99: 0 };
-            var n = sample;
-            var N = population > 0 ? population : n;
+          function computeConfidence(populationBytes, sampledBytes, failedBytes) {
+            if (sampledBytes <= 0 || failedBytes >= sampledBytes) return { c95: 0, c99: 0 };
+            var n = sampledBytes;
+            var N = populationBytes > 0 ? populationBytes : n;
             if (n > N) N = n;
-            if (failures === 0) {
+            if (failedBytes === 0) {
               var fpc = Math.sqrt((N - n) / N);
               if (fpc < 0) fpc = 0;
               return {
@@ -267,7 +267,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                 c99: Math.max(0, Math.min(100, (1 - 4.6 / n * fpc) * 100)),
               };
             }
-            var pHat = 1 - failures / n;
+            var pHat = 1 - failedBytes / n;
             return {
               c95: Math.max(0, Math.min(100, wilsonLower(pHat, n, 1.96) * 100)),
               c99: Math.max(0, Math.min(100, wilsonLower(pHat, n, 2.576) * 100)),
@@ -288,8 +288,10 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               "snapshot_time",
               "total_files",
               "total_population",
+              "sampled_bytes",
               "verified_files",
               "failed_files",
+              "failed_bytes",
               "skipped_files",
               "status",
               "started_at",
@@ -437,11 +439,13 @@ Ext.define("PBS.D2DVerification.JobPanel", {
 
                 var total = rec.get("total_files") || 0;
                 var population = rec.get("total_population") || 0;
+                var sampledBytes = rec.get("sampled_bytes") || 0;
                 var verified = rec.get("verified_files") || 0;
                 var failed = rec.get("failed_files") || 0;
+                var failedBytes = rec.get("failed_bytes") || 0;
                 var skipped = rec.get("skipped_files") || 0;
                 var snap = Ext.String.htmlEncode(rec.get("snapshot") || "");
-                var conf = computeConfidence(population, total, failed);
+                var conf = computeConfidence(population, sampledBytes, failedBytes);
 
                 summaryPanel.removeAll();
                 summaryPanel.add({
@@ -450,8 +454,8 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                     '<table style="width:100%;font-size:12px;">' +
                     '<tr>' +
                     '<td style="padding:2px 15px;"><b>Snapshot:</b> ' + snap + '</td>' +
-                    '<td style="padding:2px 15px;"><b>Population:</b> ' + (population || '-') + '</td>' +
-                    '<td style="padding:2px 15px;"><b>Sampled:</b> ' + total + '</td>' +
+                    '<td style="padding:2px 15px;"><b>Population:</b> ' + (population ? Proxmox.Utils.format_size(population) : '-') + '</td>' +
+                    '<td style="padding:2px 15px;"><b>Sampled:</b> ' + total + ' files</td>' +
                     '<td style="padding:2px 15px;color:green;"><b>Verified:</b> ' + verified + '</td>' +
                     '<td style="padding:2px 15px;color:' + (failed > 0 ? 'red' : '#888') + ';"><b>Failed:</b> ' + failed + '</td>' +
                     '<td style="padding:2px 15px;color:#888;"><b>Skipped:</b> ' + skipped + '</td>' +

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -401,7 +401,7 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       name: "sample_count_mode",
       queryMode: "local",
       store: [
-        ["absolute", "Absolute Count"],
+        ["absolute", "Absolute Size"],
         ["percent", "Percentage"],
       ],
       value: "absolute",
@@ -412,8 +412,8 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
           var panel = combo.up("pbsD2DVerificationSpotCheckPanel") ||
             combo.up("panel");
           if (!panel) return;
-          var absField = panel.down("numberfield[name=sample_count]");
-          var pctField = panel.down("numberfield[name=sample_count_percent]");
+          var absField = panel.down("[name=sample_size]");
+          var pctField = panel.down("[name=sample_size_percent]");
           if (val === "percent") {
             if (absField) absField.disable().hide();
             if (pctField) pctField.enable().show();
@@ -425,18 +425,41 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       },
     },
     {
-      xtype: "numberfield",
-      fieldLabel: gettext("Sample Count"),
-      name: "sample_count",
-      minValue: 1,
-      maxValue: 100000,
-      value: 10,
-      allowBlank: false,
+      xtype: "fieldcontainer",
+      fieldLabel: gettext("Sample Size"),
+      name: "sample_size",
+      layout: "hbox",
+      items: [
+        {
+          xtype: "numberfield",
+          name: "sample_size_value",
+          minValue: 1,
+          maxValue: 107374182400,
+          value: 1,
+          allowBlank: false,
+          flex: 1,
+        },
+        {
+          xtype: "combo",
+          name: "sample_size_unit",
+          queryMode: "local",
+          store: [
+            ["mb", "MiB"],
+            ["gb", "GiB"],
+            ["tb", "TiB"],
+          ],
+          value: "gb",
+          editable: false,
+          forceSelection: true,
+          width: 70,
+          margin: "0 0 0 5",
+        },
+      ],
     },
     {
       xtype: "numberfield",
       fieldLabel: gettext("Sample Percentage"),
-      name: "sample_count_percent",
+      name: "sample_size_percent",
       minValue: 0.01,
       maxValue: 100,
       decimalPrecision: 2,
@@ -710,11 +733,23 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
     // Flatten spot_config fields into top-level values so form fields can bind
     if (values.spot_config && Ext.isObject(values.spot_config)) {
       var sc = values.spot_config;
-      if (sc.sample_count !== undefined && values.sample_count === undefined) {
-        values.sample_count = sc.sample_count;
+
+      // Convert sample_size (bytes) to value + unit for the UI
+      if (sc.sample_size !== undefined && values.sample_size_value === undefined) {
+        var bytes = sc.sample_size;
+        if (bytes >= 1 << 40) {
+          values.sample_size_value = bytes / (1 << 40);
+          values.sample_size_unit = "tb";
+        } else if (bytes >= 1 << 30) {
+          values.sample_size_value = bytes / (1 << 30);
+          values.sample_size_unit = "gb";
+        } else {
+          values.sample_size_value = bytes / (1 << 20);
+          values.sample_size_unit = "mb";
+        }
       }
-      if (sc.sample_count_percent !== undefined && values.sample_count_percent === undefined) {
-        values.sample_count_percent = sc.sample_count_percent;
+      if (sc.sample_size_percent !== undefined && values.sample_size_percent === undefined) {
+        values.sample_size_percent = sc.sample_size_percent;
       }
       if (sc.sampling_strategy !== undefined && values.sampling_strategy === undefined) {
         values.sampling_strategy = sc.sampling_strategy;
@@ -736,7 +771,7 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       }
 
       // Set sample_count_mode based on which field has a value
-      if (sc.sample_count_percent > 0 && values.sample_count_mode === undefined) {
+      if (sc.sample_size_percent > 0 && values.sample_count_mode === undefined) {
         values.sample_count_mode = "percent";
       }
     }
@@ -786,9 +821,17 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
     var vals = me.callParent(arguments);
     var mode = vals.sample_count_mode || "absolute";
     if (mode === "percent") {
-      delete vals.sample_count;
+      delete vals.sample_size_value;
+      delete vals.sample_size_unit;
     } else {
-      delete vals.sample_count_percent;
+      delete vals.sample_size_percent;
+      // Convert value + unit to bytes
+      var val = parseFloat(vals.sample_size_value) || 1;
+      var unit = vals.sample_size_unit || "gb";
+      var mult = { mb: 1 << 20, gb: 1 << 30, tb: 1 << 40 };
+      vals.sample_size = String(Math.round(val * (mult[unit] || (1 << 30))));
+      delete vals.sample_size_value;
+      delete vals.sample_size_unit;
     }
     delete vals.sample_count_mode;
     return vals;


### PR DESCRIPTION
Replaces file-count-based sampling with byte-count-based sampling.

**Changes:**
- `SampleCount` → `SampleSize` (int64, bytes), `SampleCountPercent` → `SampleSizePercent` (% of total byte population)
- `sampleFiles` accumulates files by size until target byte count reached
- All strategies (random/systematic/stratified) work on byte targets
- Confidence intervals use byte-based population/sample/failure — "95% confident ≥X% of data bytes are intact"
- Frontend: size input with MiB/GiB/TiB unit picker
- DB migration 029: adds `sampled_bytes`, `failed_bytes` columns
- Default sample size: 1 GiB