### PR TITLE
refactor: move business logic to backend, remove dead code

### DIFF
--- a/internal/server/web/api/backup_handlers.go
+++ b/internal/server/web/api/backup_handlers.go
@@ -33,15 +33,17 @@ func D2DBackupHandler(storeInstance *store.Store) http.HandlerFunc {
 			return
 		}
 
-		digest, err := calculateDigest(allBackups)
+		flatBackups := FlattenBackups(allBackups)
+
+		digest, err := calculateDigest(flatBackups)
 		if err != nil {
 			WriteErrorResponse(w, err)
 			return
 		}
 
-		toReturn := BackupsResponse{
-			Data:   allBackups,
-			Digest: digest,
+		toReturn := map[string]any{
+			"data":   flatBackups,
+			"digest": digest,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -481,7 +483,7 @@ func ExtJsBackupSingleHandler(storeInstance *store.Store) http.HandlerFunc {
 
 			response.Status = http.StatusOK
 			response.Success = true
-			response.Data = backup
+			response.Data = FlattenBackupForEdit(backup)
 			json.NewEncoder(w).Encode(response)
 
 			return

--- a/internal/server/web/api/export_handlers.go
+++ b/internal/server/web/api/export_handlers.go
@@ -1,0 +1,247 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/server/database"
+	"github.com/pbs-plus/pbs-plus/internal/server/store"
+)
+
+// ExtJsBackupCSVExportHandler generates and returns a CSV file of all backup jobs.
+func ExtJsBackupCSVExportHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+			return
+		}
+
+		allBackups, err := storeInstance.BackupSvc.ListBackups()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		flatBackups := FlattenBackups(allBackups)
+
+		if len(flatBackups) == 0 {
+			http.Error(w, "No records to export", http.StatusNoContent)
+			return
+		}
+
+		filename := fmt.Sprintf("disk-backups-%s.csv", time.Now().Format("20060102-150405"))
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+
+		headers := []string{
+			"id", "store", "mode", "sourcemode", "readmode", "subpath", "ns",
+			"schedule", "comment", "target", "expected_size",
+			"last-run-upid", "last-run-state", "last-run-endtime",
+			"last-successful-endtime", "last-successful-upid", "duration",
+			"current_file_count", "current_folder_count",
+			"current_files_speed", "current_bytes_speed", "current_bytes_total",
+			"retry", "retry-interval", "max-dir-entries",
+			"include-xattr", "legacy-xattr",
+		}
+
+		fmt.Fprintln(w, strings.Join(headers, ","))
+
+		for _, rec := range flatBackups {
+			row := map[string]string{
+				"id":                      rec.ID,
+				"store":                   rec.Store,
+				"mode":                    rec.Mode,
+				"sourcemode":              rec.SourceMode,
+				"readmode":                rec.ReadMode,
+				"subpath":                 rec.Subpath,
+				"ns":                      rec.Namespace,
+				"schedule":                rec.Schedule,
+				"comment":                 rec.Comment,
+				"target":                  rec.Target,
+				"expected_size":           strconv.Itoa(rec.ExpectedSize),
+				"last-run-upid":           rec.LastRunUpid,
+				"last-run-state":          rec.LastRunState,
+				"last-run-endtime":        strconv.FormatInt(rec.LastRunEndtime, 10),
+				"last-successful-endtime": strconv.FormatInt(rec.LastSuccessfulEndtime, 10),
+				"last-successful-upid":    rec.LastSuccessfulUpid,
+				"duration":                strconv.FormatInt(rec.Duration, 10),
+				"current_file_count":      strconv.Itoa(rec.CurrentFileCount),
+				"current_folder_count":    strconv.Itoa(rec.CurrentFolderCount),
+				"current_files_speed":     strconv.Itoa(rec.CurrentFilesSpeed),
+				"current_bytes_speed":     strconv.Itoa(rec.CurrentBytesSpeed),
+				"current_bytes_total":     strconv.Itoa(rec.CurrentBytesTotal),
+				"retry":                   strconv.Itoa(rec.Retry),
+				"retry-interval":          strconv.Itoa(rec.RetryInterval),
+				"max-dir-entries":         strconv.Itoa(rec.MaxDirEntries),
+				"include-xattr":           strconv.FormatBool(rec.IncludeXattr),
+				"legacy-xattr":            strconv.FormatBool(rec.LegacyXattr),
+			}
+
+			var vals []string
+			for _, h := range headers {
+				v := row[h]
+				vals = append(vals, csvEscapeField(v))
+			}
+			fmt.Fprintln(w, strings.Join(vals, ","))
+		}
+	}
+}
+
+func csvEscapeField(s string) string {
+	if strings.ContainsAny(s, ",\"\n\r") {
+		return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+	}
+	return s
+}
+
+// D2DTargetTreeHandler returns targets pre-grouped into a tree structure.
+func D2DTargetTreeHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		all, err := storeInstance.TargetSvc.GetAllTargets()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		tree := BuildTargetTree(all)
+
+		digest, err := calculateDigest(tree)
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		toReturn := TargetsTreeResponse{
+			Data:   tree,
+			Digest: digest,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(toReturn)
+	}
+}
+
+// D2DBackupFlatHandler returns the flat list of backups (used by the diff store).
+func D2DBackupFlatHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+			return
+		}
+
+		allBackups, err := storeInstance.BackupSvc.ListBackups()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		flatBackups := FlattenBackups(allBackups)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": flatBackups,
+		})
+	}
+}
+
+// D2DRestoreFlatHandler returns the flat list of restores (used by the diff store).
+func D2DRestoreFlatHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+			return
+		}
+
+		allRestores, err := storeInstance.RestoreSvc.GetAllRestores()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		flatRestores := FlattenRestores(allRestores)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": flatRestores,
+		})
+	}
+}
+
+// D2DVerificationFlatHandler returns the flat list of verification jobs.
+func D2DVerificationFlatHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+			return
+		}
+
+		jobs, err := storeInstance.VerificationSvc.ListVerificationJobs()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		flatJobs := FlattenVerificationJobs(jobs)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": flatJobs,
+		})
+	}
+}
+
+// FlattenBackupForEdit flattens a Backup for the edit form GET response.
+// The edit form expects target as a string, not an object.
+func FlattenBackupForEdit(b database.Backup) map[string]any {
+	result := map[string]any{
+		"id":                b.ID,
+		"store":             b.Store,
+		"mode":              b.Mode,
+		"sourcemode":        b.SourceMode,
+		"readmode":          b.ReadMode,
+		"target":            b.Target.Name,
+		"subpath":           b.Subpath,
+		"ns":                b.Namespace,
+		"schedule":          b.Schedule,
+		"comment":           b.Comment,
+		"notification-mode": b.NotificationMode,
+		"pre_script":        b.PreScript,
+		"post_script":       b.PostScript,
+		"retry":             b.Retry,
+		"retry-interval":    b.RetryInterval,
+		"max-dir-entries":   b.MaxDirEntries,
+		"rawexclusions":     b.RawExclusions,
+		"include-xattr":     b.IncludeXattr,
+		"legacy-xattr":      b.LegacyXattr,
+	}
+	return result
+}
+
+// FlattenRestoreForEdit flattens a Restore for the edit form GET response.
+func FlattenRestoreForEdit(r database.Restore) map[string]any {
+	result := map[string]any{
+		"id":             r.ID,
+		"store":          r.Store,
+		"ns":             r.Namespace,
+		"snapshot":       r.Snapshot,
+		"src-path":       r.SrcPath,
+		"dest-target":    r.DestTarget.Name,
+		"dest-subpath":   r.DestSubpath,
+		"mode":           r.Mode,
+		"comment":        r.Comment,
+		"pre_script":     r.PreScript,
+		"post_script":    r.PostScript,
+		"retry":          r.Retry,
+		"retry-interval": r.RetryInterval,
+	}
+	return result
+}

--- a/internal/server/web/api/export_handlers.go
+++ b/internal/server/web/api/export_handlers.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pbs-plus/pbs-plus/internal/server/database"
 	"github.com/pbs-plus/pbs-plus/internal/server/store"
 )
 
@@ -92,10 +91,7 @@ func ExtJsBackupCSVExportHandler(storeInstance *store.Store) http.HandlerFunc {
 }
 
 func csvEscapeField(s string) string {
-	if strings.ContainsAny(s, ",\"\n\r") {
-		return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
-	}
-	return s
+	return csvEscape(s)
 }
 
 // D2DTargetTreeHandler returns targets pre-grouped into a tree structure.
@@ -128,120 +124,4 @@ func D2DTargetTreeHandler(storeInstance *store.Store) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(toReturn)
 	}
-}
-
-// D2DBackupFlatHandler returns the flat list of backups (used by the diff store).
-func D2DBackupFlatHandler(storeInstance *store.Store) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
-			return
-		}
-
-		allBackups, err := storeInstance.BackupSvc.ListBackups()
-		if err != nil {
-			WriteErrorResponse(w, err)
-			return
-		}
-
-		flatBackups := FlattenBackups(allBackups)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"data": flatBackups,
-		})
-	}
-}
-
-// D2DRestoreFlatHandler returns the flat list of restores (used by the diff store).
-func D2DRestoreFlatHandler(storeInstance *store.Store) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
-			return
-		}
-
-		allRestores, err := storeInstance.RestoreSvc.GetAllRestores()
-		if err != nil {
-			WriteErrorResponse(w, err)
-			return
-		}
-
-		flatRestores := FlattenRestores(allRestores)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"data": flatRestores,
-		})
-	}
-}
-
-// D2DVerificationFlatHandler returns the flat list of verification jobs.
-func D2DVerificationFlatHandler(storeInstance *store.Store) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
-			return
-		}
-
-		jobs, err := storeInstance.VerificationSvc.ListVerificationJobs()
-		if err != nil {
-			WriteErrorResponse(w, err)
-			return
-		}
-
-		flatJobs := FlattenVerificationJobs(jobs)
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"data": flatJobs,
-		})
-	}
-}
-
-// FlattenBackupForEdit flattens a Backup for the edit form GET response.
-// The edit form expects target as a string, not an object.
-func FlattenBackupForEdit(b database.Backup) map[string]any {
-	result := map[string]any{
-		"id":                b.ID,
-		"store":             b.Store,
-		"mode":              b.Mode,
-		"sourcemode":        b.SourceMode,
-		"readmode":          b.ReadMode,
-		"target":            b.Target.Name,
-		"subpath":           b.Subpath,
-		"ns":                b.Namespace,
-		"schedule":          b.Schedule,
-		"comment":           b.Comment,
-		"notification-mode": b.NotificationMode,
-		"pre_script":        b.PreScript,
-		"post_script":       b.PostScript,
-		"retry":             b.Retry,
-		"retry-interval":    b.RetryInterval,
-		"max-dir-entries":   b.MaxDirEntries,
-		"rawexclusions":     b.RawExclusions,
-		"include-xattr":     b.IncludeXattr,
-		"legacy-xattr":      b.LegacyXattr,
-	}
-	return result
-}
-
-// FlattenRestoreForEdit flattens a Restore for the edit form GET response.
-func FlattenRestoreForEdit(r database.Restore) map[string]any {
-	result := map[string]any{
-		"id":             r.ID,
-		"store":          r.Store,
-		"ns":             r.Namespace,
-		"snapshot":       r.Snapshot,
-		"src-path":       r.SrcPath,
-		"dest-target":    r.DestTarget.Name,
-		"dest-subpath":   r.DestSubpath,
-		"mode":           r.Mode,
-		"comment":        r.Comment,
-		"pre_script":     r.PreScript,
-		"post_script":    r.PostScript,
-		"retry":          r.Retry,
-		"retry-interval": r.RetryInterval,
-	}
-	return result
 }

--- a/internal/server/web/api/flatten.go
+++ b/internal/server/web/api/flatten.go
@@ -386,3 +386,48 @@ func renderFileStatusHuman(status string) string {
 		return status
 	}
 }
+
+// FlattenBackupForEdit flattens a Backup for the edit form GET response.
+// The edit form expects target as a string, not an object.
+func FlattenBackupForEdit(b database.Backup) map[string]any {
+	return map[string]any{
+		"id":                b.ID,
+		"store":             b.Store,
+		"mode":              b.Mode,
+		"sourcemode":        b.SourceMode,
+		"readmode":          b.ReadMode,
+		"target":            b.Target.Name,
+		"subpath":           b.Subpath,
+		"ns":                b.Namespace,
+		"schedule":          b.Schedule,
+		"comment":           b.Comment,
+		"notification-mode": b.NotificationMode,
+		"pre_script":        b.PreScript,
+		"post_script":       b.PostScript,
+		"retry":             b.Retry,
+		"retry-interval":    b.RetryInterval,
+		"max-dir-entries":   b.MaxDirEntries,
+		"rawexclusions":     b.RawExclusions,
+		"include-xattr":     b.IncludeXattr,
+		"legacy-xattr":      b.LegacyXattr,
+	}
+}
+
+// FlattenRestoreForEdit flattens a Restore for the edit form GET response.
+func FlattenRestoreForEdit(r database.Restore) map[string]any {
+	return map[string]any{
+		"id":             r.ID,
+		"store":          r.Store,
+		"ns":             r.Namespace,
+		"snapshot":       r.Snapshot,
+		"src-path":       r.SrcPath,
+		"dest-target":    r.DestTarget.Name,
+		"dest-subpath":   r.DestSubpath,
+		"mode":           r.Mode,
+		"comment":        r.Comment,
+		"pre_script":     r.PreScript,
+		"post_script":    r.PostScript,
+		"retry":          r.Retry,
+		"retry-interval": r.RetryInterval,
+	}
+}

--- a/internal/server/web/api/flatten.go
+++ b/internal/server/web/api/flatten.go
@@ -1,0 +1,388 @@
+package api
+
+import (
+	"github.com/pbs-plus/pbs-plus/internal/server/database"
+)
+
+// FlattenBackup converts a database.Backup into a flat API response.
+func FlattenBackup(b database.Backup) FlatBackup {
+	fb := FlatBackup{
+		ID:               b.ID,
+		Store:            b.Store,
+		Mode:             b.Mode,
+		SourceMode:       b.SourceMode,
+		ReadMode:         b.ReadMode,
+		Subpath:          b.Subpath,
+		Namespace:        b.Namespace,
+		Schedule:         b.Schedule,
+		Comment:          b.Comment,
+		NotificationMode: b.NotificationMode,
+		PreScript:        b.PreScript,
+		PostScript:       b.PostScript,
+		NextRun:          b.NextRun,
+		Retry:            b.Retry,
+		RetryInterval:    b.RetryInterval,
+		MaxDirEntries:    b.MaxDirEntries,
+		RawExclusions:    b.RawExclusions,
+		IncludeXattr:     b.IncludeXattr,
+		LegacyXattr:      b.LegacyXattr,
+
+		// Flatten target
+		Target: b.Target.Name,
+
+		// Flatten history
+		LastRunUpid:           b.History.LastRunUpid,
+		LastRunState:          b.History.LastRunState,
+		LastRunEndtime:        b.History.LastRunEndtime,
+		LastSuccessfulEndtime: b.History.LastSuccessfulEndtime,
+		LastSuccessfulUpid:    b.History.LastSuccessfulUpid,
+		Duration:              b.History.Duration,
+
+		// Flatten current-stats
+		CurrentFileCount:   b.CurrentStats.CurrentFileCount,
+		CurrentFolderCount: b.CurrentStats.CurrentFolderCount,
+		CurrentFilesSpeed:  b.CurrentStats.CurrentFilesSpeed,
+		CurrentBytesSpeed:  b.CurrentStats.CurrentBytesSpeed,
+		CurrentBytesTotal:  b.CurrentStats.CurrentBytesTotal,
+	}
+
+	// Flatten target object info
+	if b.Target.Name != "" {
+		fb.ExpectedSize = b.Target.VolumeUsedBytes
+		fb.TargetSizeHuman = HumanReadableBytes(b.Target.VolumeUsedBytes)
+	}
+
+	// Pre-format display fields
+	if b.CurrentStats.CurrentBytesSpeed > 0 {
+		fb.ReadSpeedHuman = HumanReadableSpeed(b.CurrentStats.CurrentBytesSpeed)
+	}
+	if b.CurrentStats.CurrentBytesTotal > 0 {
+		fb.ReadTotalHuman = HumanReadableBytes(b.CurrentStats.CurrentBytesTotal)
+	}
+	if b.CurrentStats.CurrentFilesSpeed > 0 {
+		fb.ProcessingSpeedHuman = FormatSpeed(b.CurrentStats.CurrentFilesSpeed)
+	}
+
+	// Parse task status
+	fb.StatusParsed = ParseTaskStatus(b.History.LastRunState)
+
+	return fb
+}
+
+// FlattenBackups converts a slice of backups to flat responses.
+func FlattenBackups(backups []database.Backup) []FlatBackup {
+	result := make([]FlatBackup, len(backups))
+	for i := range backups {
+		result[i] = FlattenBackup(backups[i])
+	}
+	return result
+}
+
+// FlattenRestore converts a database.Restore into a flat API response.
+func FlattenRestore(r database.Restore) FlatRestore {
+	fr := FlatRestore{
+		ID:            r.ID,
+		Store:         r.Store,
+		Namespace:     r.Namespace,
+		Snapshot:      r.Snapshot,
+		SrcPath:       r.SrcPath,
+		DestSubpath:   r.DestSubpath,
+		PreScript:     r.PreScript,
+		PostScript:    r.PostScript,
+		Comment:       r.Comment,
+		Retry:         r.Retry,
+		RetryInterval: r.RetryInterval,
+
+		// Flatten dest-target
+		DestTarget: r.DestTarget.Name,
+
+		// Flatten history
+		LastRunUpid:           r.History.LastRunUpid,
+		LastRunState:          r.History.LastRunState,
+		LastRunEndtime:        r.History.LastRunEndtime,
+		LastSuccessfulEndtime: r.History.LastSuccessfulEndtime,
+		LastSuccessfulUpid:    r.History.LastSuccessfulUpid,
+		Duration:              r.History.Duration,
+
+		// Flatten current-stats
+		CurrentFileCount:   r.CurrentStats.CurrentFileCount,
+		CurrentFolderCount: r.CurrentStats.CurrentFolderCount,
+		CurrentFilesSpeed:  r.CurrentStats.CurrentFilesSpeed,
+		CurrentBytesSpeed:  r.CurrentStats.CurrentBytesSpeed,
+		CurrentBytesTotal:  r.CurrentStats.CurrentBytesTotal,
+	}
+
+	// Flatten dest-target object info
+	if r.DestTarget.Name != "" {
+		fr.ExpectedSize = r.DestTarget.VolumeUsedBytes
+		fr.TargetSizeHuman = HumanReadableBytes(r.DestTarget.VolumeUsedBytes)
+	}
+
+	// Pre-format display fields
+	if r.CurrentStats.CurrentBytesSpeed > 0 {
+		fr.ReadSpeedHuman = HumanReadableSpeed(r.CurrentStats.CurrentBytesSpeed)
+	}
+	if r.CurrentStats.CurrentBytesTotal > 0 {
+		fr.ReadTotalHuman = HumanReadableBytes(r.CurrentStats.CurrentBytesTotal)
+	}
+	if r.CurrentStats.CurrentFilesSpeed > 0 {
+		fr.ProcessingSpeedHuman = FormatSpeed(r.CurrentStats.CurrentFilesSpeed)
+	}
+
+	// Parse task status
+	fr.StatusParsed = ParseTaskStatus(r.History.LastRunState)
+
+	return fr
+}
+
+// FlattenRestores converts a slice of restores to flat responses.
+func FlattenRestores(restores []database.Restore) []FlatRestore {
+	result := make([]FlatRestore, len(restores))
+	for i := range restores {
+		result[i] = FlattenRestore(restores[i])
+	}
+	return result
+}
+
+// FlattenVerificationJob converts a database.VerificationJob into a flat API response.
+func FlattenVerificationJob(vj database.VerificationJob) FlatVerificationJob {
+	fvj := FlatVerificationJob{
+		ID:                  vj.ID,
+		BackupJobID:         vj.BackupJobID,
+		Store:               vj.Store,
+		Namespace:           vj.Namespace,
+		Mode:                vj.Mode,
+		Schedule:            vj.Schedule,
+		Comment:             vj.Comment,
+		NextRun:             vj.NextRun,
+		Retry:               vj.Retry,
+		RetryInterval:       vj.RetryInterval,
+		TargetMode:          vj.TargetMode,
+		Recursive:           vj.Recursive,
+		RunOnBackupComplete: vj.RunOnBackupComplete,
+		CreatedAt:           vj.CreatedAt,
+
+		// Flatten history
+		LastRunUpid:           vj.History.LastRunUpid,
+		LastRunState:          vj.History.LastRunState,
+		LastRunStarttime:      vj.History.LastRunStarttime,
+		LastRunEndtime:        vj.History.LastRunEndtime,
+		LastSuccessfulEndtime: vj.History.LastSuccessfulEndtime,
+		LastSuccessfulUpid:    vj.History.LastSuccessfulUpid,
+		Duration:              vj.History.Duration,
+
+		// Flatten spot_config
+		SpotConfig: SpotCheckConfigJSON{
+			SampleCount:        vj.SpotConfig.SampleCount,
+			SampleCountPercent: vj.SpotConfig.SampleCountPercent,
+			SamplingStrategy:   vj.SpotConfig.SamplingStrategy,
+			UseLatest:          vj.SpotConfig.UseLatest,
+			DateFrom:           vj.SpotConfig.DateFrom,
+			DateTo:             vj.SpotConfig.DateTo,
+			FailThreshold:      vj.SpotConfig.FailThreshold,
+		},
+	}
+
+	// Convert filters
+	for _, f := range vj.SpotConfig.Filters {
+		fvj.SpotConfig.Filters = append(fvj.SpotConfig.Filters, SpotCheckFilterJSON{
+			PathPattern: f.PathPattern,
+			MinSize:     f.MinSize,
+			MaxSize:     f.MaxSize,
+		})
+	}
+
+	// Parse task status
+	fvj.StatusParsed = ParseTaskStatus(vj.History.LastRunState)
+
+	return fvj
+}
+
+// FlattenVerificationJobs converts a slice of verification jobs to flat responses.
+func FlattenVerificationJobs(jobs []database.VerificationJob) []FlatVerificationJob {
+	result := make([]FlatVerificationJob, len(jobs))
+	for i := range jobs {
+		result[i] = FlattenVerificationJob(jobs[i])
+	}
+	return result
+}
+
+// FlattenVerificationResult converts a VerificationResult with pre-computed display fields.
+func FlattenVerificationResult(r database.VerificationResult) FlatVerificationResult {
+	fr := FlatVerificationResult{
+		ID:                r.ID,
+		VerificationJobID: r.VerificationJobID,
+		UPID:              r.UPID,
+		Snapshot:          r.Snapshot,
+		SnapshotTime:      r.SnapshotTime,
+		TotalPopulation:   r.TotalPopulation,
+		TotalFiles:        r.TotalFiles,
+		VerifiedFiles:     r.VerifiedFiles,
+		FailedFiles:       r.FailedFiles,
+		SkippedFiles:      r.SkippedFiles,
+		Status:            r.Status,
+		StartedAt:         r.StartedAt,
+		CompletedAt:       r.CompletedAt,
+		Confidence:        ComputeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles),
+	}
+
+	// Duration
+	if r.StartedAt > 0 && r.CompletedAt > r.StartedAt {
+		secs := r.CompletedAt - r.StartedAt
+		fr.DurationHuman = FormatDuration(secs)
+	}
+
+	// Pass rate
+	if r.TotalFiles > 0 {
+		fr.PassRate = float64(r.VerifiedFiles) / float64(r.TotalFiles) * 100
+	}
+
+	// Flatten file details
+	for _, f := range r.Details {
+		fr.Details = append(fr.Details, FlatVerificationFileResult{
+			Path:        f.Path,
+			Size:        f.Size,
+			SizeHuman:   HumanReadableBytes(int(f.Size)),
+			Status:      f.Status,
+			StatusHuman: renderFileStatusHuman(f.Status),
+			Message:     f.Message,
+		})
+	}
+
+	return fr
+}
+
+// FlattenVerificationResults converts a slice of verification results.
+func FlattenVerificationResults(results []database.VerificationResult) []FlatVerificationResult {
+	fr := make([]FlatVerificationResult, len(results))
+	for i := range results {
+		fr[i] = FlattenVerificationResult(results[i])
+	}
+	return fr
+}
+
+// BuildTargetTree groups targets into a tree structure by type (local/agent/s3).
+func BuildTargetTree(targets []database.Target) []TargetTreeNode {
+	var localTargets []TargetTreeNode
+	agentGroups := map[string]*TargetTreeNode{}
+	var s3Targets []TargetTreeNode
+
+	for i := range targets {
+		t := targets[i]
+		node := TargetTreeNode{
+			Text:             t.Name,
+			Name:             t.Name,
+			Path:             t.Path,
+			TargetType:       string(t.Type),
+			MountScript:      t.MountScript,
+			VolumeID:         t.VolumeID,
+			JobCount:         t.JobCount,
+			AgentVersion:     t.AgentVersion,
+			ConnectionStatus: t.ConnectionStatus,
+			VolumeType:       t.VolumeType,
+			VolumeName:       t.VolumeName,
+			VolumeFS:         t.VolumeFS,
+			VolumeTotalBytes: t.VolumeTotalBytes,
+			VolumeUsedBytes:  t.VolumeUsedBytes,
+			VolumeFreeBytes:  t.VolumeFreeBytes,
+			VolumeTotalHuman: t.VolumeTotal,
+			VolumeUsedHuman:  t.VolumeUsed,
+			VolumeFreeHuman:  t.VolumeFree,
+			Leaf:             true,
+			IsGroup:          false,
+		}
+
+		switch t.Type {
+		case database.TargetTypeAgent:
+			hostname := t.AgentHost.Name
+			node.AgentHostname = hostname
+			node.OS = t.AgentHost.OperatingSystem
+			node.IP = t.AgentHost.IP
+			node.IconCls = "fa fa-hdd-o"
+
+			if hostname != "" {
+				if _, ok := agentGroups[hostname]; !ok {
+					agentGroups[hostname] = &TargetTreeNode{
+						Text:      hostname,
+						IconCls:   "fa fa-server",
+						IsGroup:   true,
+						GroupType: "agent",
+						Expanded:  true,
+						OS:        t.AgentHost.OperatingSystem,
+						IP:        t.AgentHost.IP,
+					}
+				}
+				agentGroups[hostname].Children = append(agentGroups[hostname].Children, node)
+			} else {
+				node.IconCls = "fa fa-hdd-o"
+				localTargets = append(localTargets, node)
+			}
+
+		case database.TargetTypeS3:
+			node.IconCls = "fa fa-cloud"
+			s3Targets = append(s3Targets, node)
+
+		default:
+			node.IconCls = "fa fa-folder"
+			localTargets = append(localTargets, node)
+		}
+	}
+
+	var rootChildren []TargetTreeNode
+
+	if len(localTargets) > 0 {
+		rootChildren = append(rootChildren, TargetTreeNode{
+			Text:      "Local Targets",
+			IconCls:   "fa fa-desktop",
+			IsGroup:   true,
+			GroupType: "local",
+			Expanded:  true,
+			Children:  localTargets,
+		})
+	}
+
+	if len(agentGroups) > 0 {
+		var agentChildren []TargetTreeNode
+		for _, group := range agentGroups {
+			agentChildren = append(agentChildren, *group)
+		}
+		rootChildren = append(rootChildren, TargetTreeNode{
+			Text:      "Agent Targets",
+			IconCls:   "fa fa-sitemap",
+			IsGroup:   true,
+			GroupType: "agent-root",
+			Expanded:  true,
+			Children:  agentChildren,
+		})
+	}
+
+	if len(s3Targets) > 0 {
+		rootChildren = append(rootChildren, TargetTreeNode{
+			Text:      "S3 Targets",
+			IconCls:   "fa fa-cloud",
+			IsGroup:   true,
+			GroupType: "s3",
+			Expanded:  true,
+			Children:  s3Targets,
+		})
+	}
+
+	return rootChildren
+}
+
+func renderFileStatusHuman(status string) string {
+	switch status {
+	case "ok":
+		return "✓ OK"
+	case "failed":
+		return "✗ Failed"
+	case "skipped":
+		return "○ Skipped"
+	case "warning":
+		return "⚠ Warning"
+	case "error":
+		return "⚠ Error"
+	default:
+		return status
+	}
+}

--- a/internal/server/web/api/flatten.go
+++ b/internal/server/web/api/flatten.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"sort"
+
 	"github.com/pbs-plus/pbs-plus/internal/server/database"
 )
 
@@ -343,8 +345,13 @@ func BuildTargetTree(targets []database.Target) []TargetTreeNode {
 
 	if len(agentGroups) > 0 {
 		var agentChildren []TargetTreeNode
-		for _, group := range agentGroups {
-			agentChildren = append(agentChildren, *group)
+		hostnames := make([]string, 0, len(agentGroups))
+		for name := range agentGroups {
+			hostnames = append(hostnames, name)
+		}
+		sort.Strings(hostnames)
+		for _, name := range hostnames {
+			agentChildren = append(agentChildren, *agentGroups[name])
 		}
 		rootChildren = append(rootChildren, TargetTreeNode{
 			Text:      "Agent Targets",
@@ -429,5 +436,12 @@ func FlattenRestoreForEdit(r database.Restore) map[string]any {
 		"post_script":    r.PostScript,
 		"retry":          r.Retry,
 		"retry-interval": r.RetryInterval,
+		"history": map[string]any{
+			"last-run-state":          r.History.LastRunState,
+			"last-run-upid":           r.History.LastRunUpid,
+			"last-run-endtime":        r.History.LastRunEndtime,
+			"last-successful-endtime": r.History.LastSuccessfulEndtime,
+			"last-successful-upid":    r.History.LastSuccessfulUpid,
+		},
 	}
 }

--- a/internal/server/web/api/format.go
+++ b/internal/server/web/api/format.go
@@ -118,19 +118,70 @@ func FormatDuration(seconds int64) string {
 	}
 }
 
-// ComputeConfidenceJSON returns confidence info suitable for JSON responses.
+// ConfidenceInfo holds confidence percentages for JSON responses.
 type ConfidenceInfo struct {
 	Confidence95 float64 `json:"c95"` // percentage 0-100
 	Confidence99 float64 `json:"c99"` // percentage 0-100
 }
 
 // ComputeConfidence computes statistical confidence for verification results.
+// Returns the lower bound of the intact rate at 95% and 99% confidence.
+// Uses the Rule of Three for zero-failure samples and the Wilson score interval otherwise.
 func ComputeConfidence(population, sample, failures int) ConfidenceInfo {
-	c95, c99 := computeConfidence(population, sample, failures)
+	if sample <= 0 || failures >= sample {
+		return ConfidenceInfo{}
+	}
+
+	n := float64(sample)
+	N := float64(population)
+	if N <= 0 || n > N {
+		N = n
+	}
+
+	fHat := float64(failures) / n
+
+	var c95, c99 float64
+
+	if failures == 0 {
+		// Rule of Three with finite population correction
+		fpc := math.Sqrt((N - n) / N)
+		if fpc < 0 {
+			fpc = 0
+		}
+		c95 = clamp01(1 - 3.0/n*fpc)
+		c99 = clamp01(1 - 4.6/n*fpc)
+	} else {
+		// Wilson score interval for non-zero failures
+		pHat := 1 - fHat
+		c95 = wilsonLower(pHat, n, 1.96)
+		c99 = wilsonLower(pHat, n, 2.576)
+	}
+
 	return ConfidenceInfo{
-		Confidence95: math.Round(c95*1000) / 10, // round to 1 decimal
+		Confidence95: math.Round(c95*1000) / 10, // round to 1 decimal (percentage)
 		Confidence99: math.Round(c99*1000) / 10,
 	}
+}
+
+func wilsonLower(pHat, n, z float64) float64 {
+	if n <= 0 {
+		return 0
+	}
+	denom := 1 + z*z/n
+	centre := pHat + z*z/(2*n)
+	spread := z * math.Sqrt(pHat*(1-pHat)/n+z*z/(4*n*n))
+	lower := (centre - spread) / denom
+	return clamp01(lower)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
 }
 
 // FormatSpeed returns "X.XX files/s" string.

--- a/internal/server/web/api/format.go
+++ b/internal/server/web/api/format.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"fmt"
+	"math"
+)
+
+// HumanReadableBytes converts bytes to a human-readable string (e.g. "1.50 GiB").
+func HumanReadableBytes(bytes int) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+		TB = GB * 1024
+	)
+	b := float64(bytes)
+	switch {
+	case b >= TB:
+		return fmt.Sprintf("%.2f TiB", b/TB)
+	case b >= GB:
+		return fmt.Sprintf("%.2f GiB", b/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.2f MiB", b/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.2f KiB", b/KB)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// HumanReadableSpeed converts bytes/sec to a human-readable string (e.g. "1.50 GiB/s").
+func HumanReadableSpeed(bytesPerSec int) string {
+	const (
+		KB = 1024.0
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+	s := float64(bytesPerSec)
+	switch {
+	case s >= GB:
+		return fmt.Sprintf("%.2f GiB/s", s/GB)
+	case s >= MB:
+		return fmt.Sprintf("%.2f MiB/s", s/MB)
+	case s >= KB:
+		return fmt.Sprintf("%.2f KiB/s", s/KB)
+	default:
+		return fmt.Sprintf("%.2f B/s", s)
+	}
+}
+
+// ParsedTaskStatus represents a parsed task status with display info.
+type ParsedTaskStatus struct {
+	Category string `json:"category"` // "ok", "error", "warning", "unknown", "queued"
+	Icon     string `json:"icon"`     // CSS class suffix, e.g. "check good"
+	Text     string `json:"text"`     // Display text
+}
+
+// ParseTaskStatus parses a task status string and returns display information.
+func ParseTaskStatus(status string) ParsedTaskStatus {
+	if status == "" {
+		return ParsedTaskStatus{}
+	}
+
+	if status == "OK" {
+		return ParsedTaskStatus{
+			Category: "ok",
+			Icon:     "check good",
+			Text:     "OK",
+		}
+	}
+
+	if status == "unknown" {
+		return ParsedTaskStatus{
+			Category: "unknown",
+			Icon:     "question faded",
+			Text:     "unknown",
+		}
+	}
+
+	if len(status) > 9 && status[:9] == "WARNINGS:" {
+		return ParsedTaskStatus{
+			Category: "warning",
+			Icon:     "exclamation warning",
+			Text:     status,
+		}
+	}
+
+	if len(status) > 7 && status[:7] == "QUEUED:" {
+		return ParsedTaskStatus{
+			Category: "queued",
+			Icon:     "tasks faded",
+			Text:     status,
+		}
+	}
+
+	return ParsedTaskStatus{
+		Category: "error",
+		Icon:     "times critical",
+		Text:     "Error: " + status,
+	}
+}
+
+// FormatDuration formats seconds into a human-readable duration string.
+func FormatDuration(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	d := float64(seconds)
+	switch {
+	case d < 60:
+		return fmt.Sprintf("%ds", seconds)
+	case d < 3600:
+		return fmt.Sprintf("%dm %ds", seconds/60, seconds%60)
+	default:
+		h := seconds / 3600
+		m := (seconds % 3600) / 60
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+}
+
+// ComputeConfidenceJSON returns confidence info suitable for JSON responses.
+type ConfidenceInfo struct {
+	Confidence95 float64 `json:"c95"` // percentage 0-100
+	Confidence99 float64 `json:"c99"` // percentage 0-100
+}
+
+// ComputeConfidence computes statistical confidence for verification results.
+func ComputeConfidence(population, sample, failures int) ConfidenceInfo {
+	c95, c99 := computeConfidence(population, sample, failures)
+	return ConfidenceInfo{
+		Confidence95: math.Round(c95*1000) / 10, // round to 1 decimal
+		Confidence99: math.Round(c99*1000) / 10,
+	}
+}
+
+// FormatSpeed returns "X.XX files/s" string.
+func FormatSpeed(speed int) string {
+	return fmt.Sprintf("%.2f files/s", float64(speed))
+}

--- a/internal/server/web/api/restore_handlers.go
+++ b/internal/server/web/api/restore_handlers.go
@@ -51,15 +51,17 @@ func D2DRestoreHandler(storeInstance *store.Store) http.HandlerFunc {
 			allRestores[i].CurrentStats.StatCacheHits = int(stats.StatCacheHits)
 		}
 
-		digest, err := calculateDigest(allRestores)
+		flatRestores := FlattenRestores(allRestores)
+
+		digest, err := calculateDigest(flatRestores)
 		if err != nil {
 			WriteErrorResponse(w, err)
 			return
 		}
 
-		toReturn := RestoresResponse{
-			Data:   allRestores,
-			Digest: digest,
+		toReturn := map[string]any{
+			"data":   flatRestores,
+			"digest": digest,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -421,7 +423,7 @@ func ExtJsRestoreSingleHandler(storeInstance *store.Store) http.HandlerFunc {
 
 			response.Status = http.StatusOK
 			response.Success = true
-			response.Data = restore
+			response.Data = FlattenRestoreForEdit(restore)
 			json.NewEncoder(w).Encode(response)
 
 			return

--- a/internal/server/web/api/types.go
+++ b/internal/server/web/api/types.go
@@ -217,11 +217,6 @@ type TargetsTreeResponse struct {
 	Digest string           `json:"digest"`
 }
 
-type BackupsResponse struct {
-	Data   []database.Backup `json:"data"`
-	Digest string            `json:"digest"`
-}
-
 type BackupConfigResponse struct {
 	Errors  map[string]string `json:"errors"`
 	Message string            `json:"message"`
@@ -244,11 +239,6 @@ type BackupRunResponse struct {
 	Data    string            `json:"data"`
 	Status  int               `json:"status"`
 	Success bool              `json:"success"`
-}
-
-type RestoresResponse struct {
-	Data   []database.Restore `json:"data"`
-	Digest string             `json:"digest"`
 }
 
 type RestoreConfigResponse struct {

--- a/internal/server/web/api/types.go
+++ b/internal/server/web/api/types.go
@@ -4,8 +4,218 @@ import (
 	"github.com/pbs-plus/pbs-plus/internal/server/database"
 )
 
+// FlatBackup is the flattened API response for a backup job.
+// Nested fields (history, current-stats, target) are promoted to top level
+// so the JS frontend doesn't need transform logic.
+type FlatBackup struct {
+	// Identity
+	ID               string `json:"id"`
+	Store            string `json:"store"`
+	Mode             string `json:"mode"`
+	SourceMode       string `json:"sourcemode"`
+	ReadMode         string `json:"readmode"`
+	Subpath          string `json:"subpath"`
+	Namespace        string `json:"ns"`
+	Schedule         string `json:"schedule"`
+	Comment          string `json:"comment"`
+	NotificationMode string `json:"notification-mode"`
+	PreScript        string `json:"pre_script"`
+	PostScript       string `json:"post_script"`
+	NextRun          int64  `json:"next-run"`
+	Retry            int    `json:"retry"`
+	RetryInterval    int    `json:"retry-interval"`
+	MaxDirEntries    int    `json:"max-dir-entries"`
+	RawExclusions    string `json:"rawexclusions"`
+	IncludeXattr     bool   `json:"include-xattr"`
+	LegacyXattr      bool   `json:"legacy-xattr"`
 
+	// Flattened from target
+	Target       string `json:"target"`
+	ExpectedSize int    `json:"expected_size,omitempty"`
 
+	// Flattened from history
+	LastRunUpid           string `json:"last-run-upid"`
+	LastRunState          string `json:"last-run-state"`
+	LastRunEndtime        int64  `json:"last-run-endtime"`
+	LastSuccessfulEndtime int64  `json:"last-successful-endtime"`
+	LastSuccessfulUpid    string `json:"last-successful-upid"`
+	Duration              int64  `json:"duration"`
+
+	// Flattened from current-stats
+	CurrentFileCount   int `json:"current_file_count,omitempty"`
+	CurrentFolderCount int `json:"current_folder_count,omitempty"`
+	CurrentFilesSpeed  int `json:"current_files_speed,omitempty"`
+	CurrentBytesSpeed  int `json:"current_bytes_speed,omitempty"`
+	CurrentBytesTotal  int `json:"current_bytes_total,omitempty"`
+
+	// Pre-formatted display fields
+	TargetSizeHuman      string           `json:"target_size_human"`
+	ReadSpeedHuman       string           `json:"read_speed_human"`
+	ReadTotalHuman       string           `json:"read_total_human"`
+	ProcessingSpeedHuman string           `json:"processing_speed_human"`
+	StatusParsed         ParsedTaskStatus `json:"status_parsed"`
+}
+
+// FlatRestore is the flattened API response for a restore job.
+type FlatRestore struct {
+	ID            string `json:"id"`
+	Store         string `json:"store"`
+	Namespace     string `json:"ns"`
+	Snapshot      string `json:"snapshot"`
+	SrcPath       string `json:"src-path"`
+	DestSubpath   string `json:"dest-subpath"`
+	PreScript     string `json:"pre_script"`
+	PostScript    string `json:"post_script"`
+	Comment       string `json:"comment"`
+	Retry         int    `json:"retry"`
+	RetryInterval int    `json:"retry-interval"`
+	ExpectedSize  int    `json:"expected_size,omitempty"`
+
+	// Flattened from dest-target
+	DestTarget string `json:"dest-target"`
+
+	// Flattened from history
+	LastRunUpid           string `json:"last-run-upid"`
+	LastRunState          string `json:"last-run-state"`
+	LastRunEndtime        int64  `json:"last-run-endtime"`
+	LastSuccessfulEndtime int64  `json:"last-successful-endtime"`
+	LastSuccessfulUpid    string `json:"last-successful-upid"`
+	Duration              int64  `json:"duration"`
+
+	// Flattened from current-stats
+	CurrentFileCount   int `json:"current_file_count,omitempty"`
+	CurrentFolderCount int `json:"current_folder_count,omitempty"`
+	CurrentFilesSpeed  int `json:"current_files_speed,omitempty"`
+	CurrentBytesSpeed  int `json:"current_bytes_speed,omitempty"`
+	CurrentBytesTotal  int `json:"current_bytes_total,omitempty"`
+
+	// Pre-formatted display fields
+	TargetSizeHuman      string           `json:"target_size_human"`
+	ReadSpeedHuman       string           `json:"read_speed_human"`
+	ReadTotalHuman       string           `json:"read_total_human"`
+	ProcessingSpeedHuman string           `json:"processing_speed_human"`
+	StatusParsed         ParsedTaskStatus `json:"status_parsed"`
+}
+
+// FlatVerificationJob is the flattened API response for a verification job.
+type FlatVerificationJob struct {
+	ID                  string              `json:"id"`
+	BackupJobID         string              `json:"backup_job_id"`
+	Store               string              `json:"store"`
+	Namespace           string              `json:"ns"`
+	Mode                string              `json:"mode"`
+	Schedule            string              `json:"schedule"`
+	Comment             string              `json:"comment"`
+	SpotConfig          SpotCheckConfigJSON `json:"spot_config"`
+	NextRun             int64               `json:"next-run"`
+	Retry               int                 `json:"retry"`
+	RetryInterval       int                 `json:"retry-interval"`
+	TargetMode          string              `json:"target_mode"`
+	Recursive           bool                `json:"recursive"`
+	RunOnBackupComplete bool                `json:"run_on_backup_complete"`
+	CreatedAt           int64               `json:"created_at"`
+
+	// Flattened from history
+	LastRunUpid           string `json:"last-run-upid"`
+	LastRunState          string `json:"last-run-state"`
+	LastRunStarttime      int64  `json:"last-run-starttime"`
+	LastRunEndtime        int64  `json:"last-run-endtime"`
+	LastSuccessfulEndtime int64  `json:"last-successful-endtime"`
+	LastSuccessfulUpid    string `json:"last-successful-upid"`
+	Duration              int64  `json:"duration"`
+
+	// Pre-formatted
+	StatusParsed ParsedTaskStatus `json:"status_parsed"`
+}
+
+// SpotCheckConfigJSON is a simplified spot config for API responses.
+type SpotCheckConfigJSON struct {
+	SampleCount        int                   `json:"sample_count"`
+	SampleCountPercent float64               `json:"sample_count_percent"`
+	SamplingStrategy   string                `json:"sampling_strategy"`
+	UseLatest          bool                  `json:"use_latest"`
+	DateFrom           string                `json:"date_from"`
+	DateTo             string                `json:"date_to"`
+	Filters            []SpotCheckFilterJSON `json:"filters"`
+	FailThreshold      int                   `json:"fail_threshold"`
+}
+
+// SpotCheckFilterJSON is a simplified filter for API responses.
+type SpotCheckFilterJSON struct {
+	PathPattern string `json:"path_pattern"`
+	MinSize     int64  `json:"min_size"`
+	MaxSize     int64  `json:"max_size"`
+}
+
+// FlatVerificationResult extends VerificationResult with pre-computed display fields.
+type FlatVerificationResult struct {
+	ID                int                          `json:"id"`
+	VerificationJobID string                       `json:"verification_job_id"`
+	UPID              string                       `json:"upid"`
+	Snapshot          string                       `json:"snapshot"`
+	SnapshotTime      int64                        `json:"snapshot_time"`
+	TotalPopulation   int                          `json:"total_population"`
+	TotalFiles        int                          `json:"total_files"`
+	VerifiedFiles     int                          `json:"verified_files"`
+	FailedFiles       int                          `json:"failed_files"`
+	SkippedFiles      int                          `json:"skipped_files"`
+	Status            string                       `json:"status"`
+	StartedAt         int64                        `json:"started_at"`
+	CompletedAt       int64                        `json:"completed_at"`
+	DurationHuman     string                       `json:"duration_human"`
+	PassRate          float64                      `json:"pass_rate"` // percentage 0-100
+	Confidence        ConfidenceInfo               `json:"confidence"`
+	Details           []FlatVerificationFileResult `json:"details"`
+}
+
+// FlatVerificationFileResult extends VerificationFileResult with display fields.
+type FlatVerificationFileResult struct {
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	SizeHuman   string `json:"size_human"`
+	Status      string `json:"status"`
+	StatusHuman string `json:"status_human"` // e.g. "✓ OK", "✗ Failed"
+	Message     string `json:"message"`
+}
+
+// TargetTreeNode represents a node in the pre-built target tree.
+type TargetTreeNode struct {
+	Text      string           `json:"text"` // display label
+	IconCls   string           `json:"iconCls,omitempty"`
+	Expanded  bool             `json:"expanded"`
+	IsGroup   bool             `json:"isGroup"`
+	GroupType string           `json:"groupType,omitempty"`
+	Leaf      bool             `json:"leaf"`
+	Children  []TargetTreeNode `json:"children,omitempty"`
+
+	// Target fields (present when IsGroup == false)
+	Name             string `json:"name,omitempty"`
+	Path             string `json:"path,omitempty"`
+	TargetType       string `json:"target_type,omitempty"`
+	MountScript      string `json:"mount_script,omitempty"`
+	VolumeID         string `json:"volume_id,omitempty"`
+	JobCount         int    `json:"job_count,omitempty"`
+	AgentVersion     string `json:"agent_version,omitempty"`
+	ConnectionStatus bool   `json:"connection_status,omitempty"`
+	VolumeType       string `json:"volume_type,omitempty"`
+	VolumeName       string `json:"volume_name,omitempty"`
+	VolumeFS         string `json:"volume_fs,omitempty"`
+	VolumeTotalBytes int    `json:"volume_total_bytes,omitempty"`
+	VolumeUsedBytes  int    `json:"volume_used_bytes,omitempty"`
+	VolumeFreeBytes  int    `json:"volume_free_bytes,omitempty"`
+	VolumeTotalHuman string `json:"volume_total,omitempty"`
+	VolumeUsedHuman  string `json:"volume_used,omitempty"`
+	VolumeFreeHuman  string `json:"volume_free,omitempty"`
+	AgentHostname    string `json:"agent_hostname,omitempty"`
+	OS               string `json:"os,omitempty"`
+	IP               string `json:"ip,omitempty"`
+}
+
+// TargetsTreeResponse is the API response for the target tree.
+type TargetsTreeResponse struct {
+	Data   []TargetTreeNode `json:"data"`
+	Digest string           `json:"digest"`
+}
 
 type BackupsResponse struct {
 	Data   []database.Backup `json:"data"`
@@ -15,7 +225,7 @@ type BackupsResponse struct {
 type BackupConfigResponse struct {
 	Errors  map[string]string `json:"errors"`
 	Message string            `json:"message"`
-	Data    database.Backup   `json:"data"`
+	Data    any               `json:"data"`
 	Status  int               `json:"status"`
 	Success bool              `json:"success"`
 }
@@ -44,7 +254,7 @@ type RestoresResponse struct {
 type RestoreConfigResponse struct {
 	Errors  map[string]string `json:"errors"`
 	Message string            `json:"message"`
-	Data    database.Restore  `json:"data"`
+	Data    any               `json:"data"`
 	Status  int               `json:"status"`
 	Success bool              `json:"success"`
 }
@@ -56,8 +266,6 @@ type RestoreRunResponse struct {
 	Status  int               `json:"status"`
 	Success bool              `json:"success"`
 }
-
-
 
 type TargetsResponse struct {
 	Data   []database.Target `json:"data"`
@@ -80,8 +288,6 @@ type AgentConfigResponse struct {
 	Success bool               `json:"success"`
 }
 
-
-
 type TokensResponse struct {
 	Data   []database.AgentToken `json:"data"`
 	Digest string                `json:"digest"`
@@ -94,8 +300,6 @@ type TokenConfigResponse struct {
 	Status  int                 `json:"status"`
 	Success bool                `json:"success"`
 }
-
-
 
 type ExclusionsResponse struct {
 	Data   []database.Exclusion `json:"data"`
@@ -110,7 +314,6 @@ type ExclusionConfigResponse struct {
 	Success bool                `json:"success"`
 }
 
-
 type VersionResponse struct {
 	Version string `json:"version"`
 }
@@ -120,8 +323,6 @@ type ScriptConfig struct {
 	ServerUrl      string
 	BootstrapToken string
 }
-
-
 
 type ScriptsResponse struct {
 	Data   []database.Script `json:"data"`

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -18,11 +17,6 @@ import (
 	"github.com/pbs-plus/pbs-plus/internal/syslog"
 	"github.com/pbs-plus/pbs-plus/internal/validate"
 )
-
-type VerificationJobsResponse struct {
-	Data   []database.VerificationJob `json:"data"`
-	Digest string                     `json:"digest"`
-}
 
 type VerificationJobConfigResponse struct {
 	Errors  map[string]string        `json:"errors"`
@@ -38,14 +32,6 @@ type VerificationRunResponse struct {
 	Data    string            `json:"data"`
 	Status  int               `json:"status"`
 	Success bool              `json:"success"`
-}
-
-type VerificationResultsResponse struct {
-	Errors  map[string]string             `json:"errors"`
-	Message string                        `json:"message"`
-	Data    []database.VerificationResult `json:"data"`
-	Status  int                           `json:"status"`
-	Success bool                          `json:"success"`
 }
 
 // D2DVerificationHandler handles listing verification jobs.
@@ -572,7 +558,7 @@ func writeSummaryCSV(w http.ResponseWriter, results []database.VerificationResul
 	for _, r := range results {
 		startedAt := formatTimestamp(r.StartedAt)
 		completedAt := formatTimestamp(r.CompletedAt)
-		conf95, conf99 := computeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
+		conf := ComputeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
 		fmt.Fprintf(w, "%s,%d,%s,%s,%d,%d,%d,%d,%d,%.1f%%,%.1f%%,%s,%s\n",
 			csvEscape(r.VerificationJobID),
 			r.ID,
@@ -583,8 +569,8 @@ func writeSummaryCSV(w http.ResponseWriter, results []database.VerificationResul
 			r.VerifiedFiles,
 			r.FailedFiles,
 			r.SkippedFiles,
-			conf95*100,
-			conf99*100,
+			conf.Confidence95,
+			conf.Confidence99,
 			startedAt,
 			completedAt,
 		)
@@ -594,7 +580,7 @@ func writeSummaryCSV(w http.ResponseWriter, results []database.VerificationResul
 func writeDetailCSV(w http.ResponseWriter, results []database.VerificationResult) {
 	fmt.Fprintln(w, "Job ID,Run ID,Snapshot,Total Population,Sample Size,File Path,File Size,Status,Message,Confidence 95%,Confidence 99%")
 	for _, r := range results {
-		conf95, conf99 := computeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
+		conf := ComputeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles)
 		for _, f := range r.Details {
 			fmt.Fprintf(w, "%s,%d,%s,%d,%d,%s,%d,%s,%s,%.1f%%,%.1f%%\n",
 				csvEscape(r.VerificationJobID),
@@ -606,63 +592,11 @@ func writeDetailCSV(w http.ResponseWriter, results []database.VerificationResult
 				f.Size,
 				f.Status,
 				csvEscape(f.Message),
-				conf95*100,
-				conf99*100,
+				conf.Confidence95,
+				conf.Confidence99,
 			)
 		}
 	}
-}
-
-// computeConfidence returns the lower bound of the intact rate at 95% and 99% confidence.
-// Uses the Rule of Three for zero-failure samples and the Wilson score interval otherwise.
-func computeConfidence(population, sample, failures int) (float64, float64) {
-	if sample <= 0 || failures >= sample {
-		return 0, 0
-	}
-
-	n := float64(sample)
-	N := float64(population)
-	if N <= 0 || n > N {
-		N = n
-	}
-
-	fHat := float64(failures) / n
-
-	if failures == 0 {
-		// Rule of Three with finite population correction
-		fpc := math.Sqrt((N - n) / N)
-		if fpc < 0 {
-			fpc = 0
-		}
-		upper95 := 3.0 / n * fpc
-		upper99 := 4.6 / n * fpc
-		return clamp01(1 - upper95), clamp01(1 - upper99)
-	}
-
-	// Wilson score interval for non-zero failures
-	pHat := 1 - fHat
-	return wilsonLower(pHat, n, 1.96), wilsonLower(pHat, n, 2.576)
-}
-
-func wilsonLower(pHat, n, z float64) float64 {
-	if n <= 0 {
-		return 0
-	}
-	denom := 1 + z*z/n
-	centre := pHat + z*z/(2*n)
-	spread := z * math.Sqrt(pHat*(1-pHat)/n+z*z/(4*n*n))
-	lower := (centre - spread) / denom
-	return clamp01(lower)
-}
-
-func clamp01(v float64) float64 {
-	if v < 0 {
-		return 0
-	}
-	if v > 1 {
-		return 1
-	}
-	return v
 }
 
 func formatTimestamp(unix int64) string {

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -62,15 +62,17 @@ func D2DVerificationHandler(storeInstance *store.Store) http.HandlerFunc {
 			return
 		}
 
-		digest, err := calculateDigest(jobs)
+		flatJobs := FlattenVerificationJobs(jobs)
+
+		digest, err := calculateDigest(flatJobs)
 		if err != nil {
 			WriteErrorResponse(w, err)
 			return
 		}
 
-		toReturn := VerificationJobsResponse{
-			Data:   jobs,
-			Digest: digest,
+		toReturn := map[string]any{
+			"data":   flatJobs,
+			"digest": digest,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -517,10 +519,12 @@ func ExtJsVerificationResultsHandler(storeInstance *store.Store) http.HandlerFun
 			return
 		}
 
-		response := VerificationResultsResponse{
-			Status:  http.StatusOK,
-			Success: true,
-			Data:    results,
+		flatResults := FlattenVerificationResults(results)
+
+		response := map[string]any{
+			"status":  http.StatusOK,
+			"success": true,
+			"data":    flatResults,
 		}
 		json.NewEncoder(w).Encode(response)
 	}

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -45,9 +45,7 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 
 	// API routes
 	apiMux.HandleFunc("/api2/json/d2d/backup", ServerOnly(storeInstance, api.D2DBackupHandler(storeInstance)))
-	apiMux.HandleFunc("/api2/json/d2d/backup/flat", ServerOnly(storeInstance, api.D2DBackupFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/restore", ServerOnly(storeInstance, api.D2DRestoreHandler(storeInstance)))
-	apiMux.HandleFunc("/api2/json/d2d/restore/flat", ServerOnly(storeInstance, api.D2DRestoreFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/target", ServerOnly(storeInstance, api.D2DTargetHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/target/tree", ServerOnly(storeInstance, api.D2DTargetTreeHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/script", ServerOnly(storeInstance, api.D2DScriptHandler(storeInstance)))
@@ -80,7 +78,6 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 	apiMux.HandleFunc("/api2/extjs/config/disk-restore/{restore}", ServerOnly(storeInstance, api.ExtJsRestoreSingleHandler(storeInstance)))
 	apiMux.HandleFunc("/plus/agent/install/win", api.AgentInstallScriptHandler(storeInstance, version))
 	apiMux.HandleFunc("/api2/json/d2d/verification", ServerOnly(storeInstance, api.D2DVerificationHandler(storeInstance)))
-	apiMux.HandleFunc("/api2/json/d2d/verification/flat", ServerOnly(storeInstance, api.D2DVerificationFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/d2d/verification", ServerOnly(storeInstance, api.ExtJsVerificationRunHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification", ServerOnly(storeInstance, api.ExtJsVerificationConfigHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification/{id}", ServerOnly(storeInstance, api.ExtJsVerificationConfigSingleHandler(storeInstance)))

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -45,8 +45,11 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 
 	// API routes
 	apiMux.HandleFunc("/api2/json/d2d/backup", ServerOnly(storeInstance, api.D2DBackupHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/json/d2d/backup/flat", ServerOnly(storeInstance, api.D2DBackupFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/restore", ServerOnly(storeInstance, api.D2DRestoreHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/json/d2d/restore/flat", ServerOnly(storeInstance, api.D2DRestoreFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/target", ServerOnly(storeInstance, api.D2DTargetHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/json/d2d/target/tree", ServerOnly(storeInstance, api.D2DTargetTreeHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/script", ServerOnly(storeInstance, api.D2DScriptHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/token", ServerOnly(storeInstance, api.D2DTokenHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/json/d2d/filetree/{target}", ServerOnly(storeInstance, api.D2DFileTree(storeInstance)))
@@ -54,6 +57,7 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 
 	// ExtJS routes
 	apiMux.HandleFunc("/api2/extjs/d2d/backup", ServerOnly(storeInstance, api.ExtJsBackupRunHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/extjs/d2d/backup/export", ServerOnly(storeInstance, api.ExtJsBackupCSVExportHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/d2d/restore", ServerOnly(storeInstance, api.ExtJsRestoreRunHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-target", ServerOnly(storeInstance, api.ExtJsTargetHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-target-status", ServerOnly(storeInstance, api.D2DTargetStatusHandler(storeInstance)))
@@ -76,6 +80,7 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 	apiMux.HandleFunc("/api2/extjs/config/disk-restore/{restore}", ServerOnly(storeInstance, api.ExtJsRestoreSingleHandler(storeInstance)))
 	apiMux.HandleFunc("/plus/agent/install/win", api.AgentInstallScriptHandler(storeInstance, version))
 	apiMux.HandleFunc("/api2/json/d2d/verification", ServerOnly(storeInstance, api.D2DVerificationHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/json/d2d/verification/flat", ServerOnly(storeInstance, api.D2DVerificationFlatHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/d2d/verification", ServerOnly(storeInstance, api.ExtJsVerificationRunHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification", ServerOnly(storeInstance, api.ExtJsVerificationConfigHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification/{id}", ServerOnly(storeInstance, api.ExtJsVerificationConfigSingleHandler(storeInstance)))

--- a/internal/server/web/views/custom/5_models.js
+++ b/internal/server/web/views/custom/5_models.js
@@ -20,19 +20,28 @@ Ext.define("pbs-disk-backup-status", {
     "rawexclusions",
     "include-xattr",
     "legacy-xattr",
+    // Flattened from target
+    "target",
+    "expected_size",
+    // Flattened from history (now returned flat by API)
     "last-run-upid",
     "last-run-state",
     "last-run-endtime",
     "last-successful-endtime",
     "last-successful-upid",
-    "expected_size",
     "duration",
+    // Flattened from current-stats
     "current_file_count",
     "current_folder_count",
     "current_files_speed",
     "current_bytes_speed",
     "current_bytes_total",
-    "target",
+    // Pre-formatted display fields
+    "target_size_human",
+    "read_speed_human",
+    "read_total_human",
+    "processing_speed_human",
+    "status_parsed",
   ],
   idProperty: "id",
   proxy: {
@@ -41,33 +50,6 @@ Ext.define("pbs-disk-backup-status", {
     reader: {
       type: "json",
       rootProperty: "data",
-      transform: function (raw) {
-        let rows = raw.data || [];
-        return rows.map((item) => {
-          if (item.history) {
-            item["last-run-upid"] = item.history["last-run-upid"];
-            item["last-run-state"] = item.history["last-run-state"];
-            item["last-run-endtime"] = item.history["last-run-endtime"];
-            item["last-successful-endtime"] =
-              item.history["last-successful-endtime"];
-            item["last-successful-upid"] = item.history["last-successful-upid"];
-            item["duration"] = item.history["duration"] || null;
-          }
-          if (item["current-stats"]) {
-            let s = item["current-stats"];
-            item.current_file_count = s.current_file_count || null;
-            item.current_folder_count = s.current_folder_count || null;
-            item.current_files_speed = s.current_files_speed || null;
-            item.current_bytes_speed = s.current_bytes_speed || null;
-            item.current_bytes_total = s.current_bytes_total || null;
-          }
-          if (item.target && Ext.isObject(item.target)) {
-            item.target = item.target.name;
-            item.expected_size = item.target.volume_used_bytes;
-          }
-          return item;
-        });
-      },
     },
   },
 });
@@ -87,18 +69,27 @@ Ext.define("pbs-disk-restore-job-status", {
     "retry",
     "retry-interval",
     "expected_size",
+    // Flattened from dest-target
+    "dest-target",
+    // Flattened from history
     "last-run-upid",
     "last-run-state",
     "last-run-endtime",
     "last-successful-endtime",
     "last-successful-upid",
     "duration",
+    // Flattened from current-stats
     "current_file_count",
     "current_folder_count",
     "current_files_speed",
     "current_bytes_speed",
     "current_bytes_total",
-    "dest-target",
+    // Pre-formatted display fields
+    "target_size_human",
+    "read_speed_human",
+    "read_total_human",
+    "processing_speed_human",
+    "status_parsed",
   ],
   idProperty: "id",
   proxy: {
@@ -107,33 +98,6 @@ Ext.define("pbs-disk-restore-job-status", {
     reader: {
       type: "json",
       rootProperty: "data",
-      transform: function (raw) {
-        let rows = raw.data || [];
-        return rows.map((item) => {
-          if (item.history) {
-            item["last-run-upid"] = item.history["last-run-upid"];
-            item["last-run-state"] = item.history["last-run-state"];
-            item["last-run-endtime"] = item.history["last-run-endtime"];
-            item["last-successful-endtime"] =
-              item.history["last-successful-endtime"];
-            item["last-successful-upid"] = item.history["last-successful-upid"];
-            item["duration"] = item.history["duration"] || null;
-          }
-          if (item["current-stats"]) {
-            let s = item["current-stats"];
-            item.current_file_count = s.current_file_count || null;
-            item.current_folder_count = s.current_folder_count || null;
-            item.current_files_speed = s.current_files_speed || null;
-            item.current_bytes_speed = s.current_bytes_speed || null;
-            item.current_bytes_total = s.current_bytes_total || null;
-          }
-          if (item["dest-target"] && Ext.isObject(item["dest-target"])) {
-            item["dest-target"] = item["dest-target"].name;
-            item.expected_size = item["dest-target"].volume_used_bytes;
-          }
-          return item;
-        });
-      },
     },
   },
 });
@@ -238,11 +202,7 @@ Ext.define("pbs-verification-job-status", {
     "retry",
     "retry-interval",
     "created_at",
-    {
-      name: "history",
-      defaultValue: {},
-    },
-    // Flattened history fields (populated by reader transform)
+    // Flattened from history (now returned flat by API)
     "last-run-upid",
     "last-run-state",
     "last-run-endtime",
@@ -250,6 +210,8 @@ Ext.define("pbs-verification-job-status", {
     "last-successful-endtime",
     "last-successful-upid",
     "duration",
+    // Pre-formatted
+    "status_parsed",
   ],
   idProperty: "id",
   proxy: {
@@ -258,22 +220,6 @@ Ext.define("pbs-verification-job-status", {
     reader: {
       type: "json",
       rootProperty: "data",
-      transform: function (raw) {
-        var rows = raw.data || [];
-        return rows.map(function (item) {
-          if (item.history) {
-            item["last-run-upid"] = item.history["last-run-upid"];
-            item["last-run-state"] = item.history["last-run-state"];
-            item["last-run-endtime"] = item.history["last-run-endtime"];
-            item["last-run-starttime"] = item.history["last-run-starttime"];
-            item["last-successful-endtime"] =
-              item.history["last-successful-endtime"];
-            item["last-successful-upid"] = item.history["last-successful-upid"];
-            item["duration"] = item.history["duration"] || null;
-          }
-          return item;
-        });
-      },
     },
   },
 });

--- a/internal/server/web/views/custom/panels/backups.js
+++ b/internal/server/web/views/custom/panels/backups.js
@@ -403,136 +403,11 @@ Ext.define("PBS.config.DiskBackupJobView", {
 
     exportCSV: async function () {
       const view = this.getView();
-      const store = view.getStore();
-      const records = store.getData().items.map((item) => item.data);
-
-      if (!records || records.length === 0) {
-        Ext.Msg.alert(gettext("Info"), gettext("No records to export."));
-        return;
-      }
-
-      async function fetchSnapshotData(job) {
-        // Build URL using job.store and job.ns.
-        const url = `/api2/json/admin/datastore/${encodeURIComponent(
-          job.store,
-        )}/snapshots?ns=${encodeURIComponent(job.ns)}`;
-
-        try {
-          const response = await fetch(url);
-          if (!response.ok) {
-            throw new Error("HTTP error " + response.status);
-          }
-          const resData = await response.json();
-          const snapshots = resData.data || [];
-          let totalSize = 0;
-
-          const backupTimes = [];
-
-          snapshots.forEach((snap) => {
-            totalSize += snap.size || 0;
-            if (Object.prototype.hasOwnProperty.call(snap, "backup-time")) {
-              let t = snap["backup-time"];
-              if (typeof t !== "number") {
-                t = parseInt(t, 10);
-              }
-              if (Number.isInteger(t)) {
-                backupTimes.push(t);
-              }
-            }
-          });
-
-          return {
-            snapshotCount: snapshots.length,
-            snapshotTotalSize: totalSize,
-            snapshotAttributes: { "backup-time": backupTimes },
-          };
-        } catch (error) {
-          console.error("Error fetching snapshots for job:", job.id, error);
-          return {
-            snapshotCount: "error",
-            snapshotTotalSize: "error",
-            snapshotAttributes: {},
-          };
-        }
-      }
-
-      async function processRecords(records) {
-        // Fetch snapshot data for all jobs in parallel.
-        const extraDataArray = await Promise.all(
-          records.map((job) => fetchSnapshotData(job)),
-        );
-
-        // Merge each job's data with the corresponding snapshot data.
-        const mergedRecords = records.map((job, idx) => {
-          const extra = extraDataArray[idx];
-
-          // Process only the "backup-time" attribute.
-          const backupTimes = extra.snapshotAttributes["backup-time"] || [];
-          const snapshotBackupTime = JSON.stringify(
-            backupTimes.map((timestamp) =>
-              new Date(timestamp * 1000).toString(),
-            ),
-          );
-
-          // Remove unwanted job properties.
-          delete job.exclusions;
-          delete job.upids;
-          delete job["last-plus-error"];
-
-          return {
-            ...job,
-            snapshotCount: extra.snapshotCount,
-            snapshotTotalSize: extra.snapshotTotalSize,
-            snapshot_backup_time: snapshotBackupTime,
-          };
-        });
-
-        return mergedRecords;
-      }
-
-      // Collect the union of all keys across merged records to serve as CSV
-      // headers.
-      var mergedRecords = [];
-      try {
-        mergedRecords = await processRecords(records);
-        console.log("Merged Records:", mergedRecords);
-      } catch (error) {
-        console.error("Error processing records:", error);
-      }
-
-      const headerSet = new Set();
-      mergedRecords.forEach((record) => {
-        Object.keys(record).forEach((key) => headerSet.add(key));
-      });
-
-      const headers = Array.from(headerSet);
-
-      // Build CSV rows.
-      const csvRows = [];
-      csvRows.push(headers.join(","));
-
-      mergedRecords.forEach((row) => {
-        const values = headers.map((header) => {
-          let val = row[header] != null ? row[header] : "";
-          // Escape double quotes.
-          val = String(val).replace(/"/g, '""');
-          return `"${val}"`;
-        });
-        csvRows.push(values.join(","));
-      });
-
-      const csvText = csvRows.join("\n");
-
-      // Create a Blob and trigger the download.
-      const blob = new Blob([csvText], { type: "text/csv" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "disk-backups.csv";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      const encodedId = encodeURIComponent(1);
+      window.open(
+        pbsPlusBaseUrl + "/api2/extjs/d2d/backup/export",
+        "_blank"
+      );
     },
 
     startStore: function () {
@@ -827,45 +702,33 @@ Ext.define("PBS.config.DiskBackupJobView", {
     },
     {
       text: gettext("Read Speed"),
-      dataIndex: "current_bytes_speed",
+      dataIndex: "read_speed_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableSpeed(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Read Total"),
-      dataIndex: "current_bytes_total",
+      dataIndex: "read_total_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableBytes(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Target Size"),
-      dataIndex: "expected_size",
+      dataIndex: "target_size_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableBytes(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Processing Speed"),
-      dataIndex: "current_files_speed",
+      dataIndex: "processing_speed_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return `${value.toFixed(2)} files/s`;
+        return value || "-";
       },
       width: 60,
     },

--- a/internal/server/web/views/custom/panels/restores.js
+++ b/internal/server/web/views/custom/panels/restores.js
@@ -453,45 +453,33 @@ Ext.define("PBS.config.DiskRestoreJobView", {
     },
     {
       text: gettext("Read Speed"),
-      dataIndex: "current_bytes_speed",
+      dataIndex: "read_speed_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableSpeed(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Read Total"),
-      dataIndex: "current_bytes_total",
+      dataIndex: "read_total_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableBytes(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Target Size"),
-      dataIndex: "expected_size",
+      dataIndex: "target_size_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return humanReadableBytes(value);
+        return value || "-";
       },
       width: 60,
     },
     {
       text: gettext("Processing Speed"),
-      dataIndex: "current_files_speed",
+      dataIndex: "processing_speed_human",
       renderer: function (value) {
-        if (!value && value !== 0) {
-          return "-";
-        }
-        return `${value.toFixed(2)} files/s`;
+        return value || "-";
       },
       width: 60,
     },

--- a/internal/server/web/views/custom/panels/targets.js
+++ b/internal/server/web/views/custom/panels/targets.js
@@ -188,60 +188,46 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
     }
 
     if (!searchValue) {
-      // No search, show all
-      me.buildTree(me.allTargetsData);
+      // No search, reload tree from server
+      me.loadData();
       return;
     }
 
-    // Filter targets based on search
-    let filteredTargets = me.allTargetsData.filter((target) => {
-      let targetData = target.getData();
+    // Filter: reload tree and then hide non-matching nodes
+    // For simplicity, we filter client-side after loading
+    let filtered = me.allTargetsData.filter(function (node) {
+      let d = node.data;
       return (
-        (targetData.name &&
-          targetData.name.toLowerCase().includes(searchValue)) ||
-        (targetData.path &&
-          targetData.path.toLowerCase().includes(searchValue)) ||
-        (targetData.agent_hostname &&
-          targetData.agent_hostname.toLowerCase().includes(searchValue)) ||
-        (targetData.ip && targetData.ip.toLowerCase().includes(searchValue)) ||
-        (targetData.volume_name &&
-          targetData.volume_name.toLowerCase().includes(searchValue)) ||
-        (targetData.volume_type &&
-          targetData.volume_type.toLowerCase().includes(searchValue)) ||
-        (targetData.target_type &&
-          targetData.target_type.toLowerCase().includes(searchValue))
+        (d.name && d.name.toLowerCase().includes(searchValue)) ||
+        (d.path && d.path.toLowerCase().includes(searchValue)) ||
+        (d.agent_hostname && d.agent_hostname.toLowerCase().includes(searchValue)) ||
+        (d.ip && d.ip.toLowerCase().includes(searchValue)) ||
+        (d.volume_name && d.volume_name.toLowerCase().includes(searchValue)) ||
+        (d.volume_type && d.volume_type.toLowerCase().includes(searchValue)) ||
+        (d.target_type && d.target_type.toLowerCase().includes(searchValue))
       );
     });
 
-    me.buildTree(filteredTargets);
-  },
-
-  buildTree: function (targets) {
-    let me = this;
-    let view = me.getView();
-
+    // Build filtered tree
     let localTargets = [];
     let agentGroups = {};
     let s3Targets = [];
 
-    targets.forEach((target) => {
-      let targetData = target.getData();
+    filtered.forEach(function (node) {
+      let targetData = node.data;
+      let treeNode = Ext.apply({}, targetData);
+      treeNode.leaf = true;
+      treeNode.isGroup = false;
 
       if (targetData.target_type === "agent") {
-        let hostname =
-          targetData.agent_hostname ||
-          (targetData.agent_host && targetData.agent_host.name);
-        let os =
-          targetData.os || (targetData.agent_host && targetData.agent_host.os);
-        let ip =
-          targetData.ip || (targetData.agent_host && targetData.agent_host.ip);
-
+        let hostname = targetData.agent_hostname;
+        treeNode.iconCls = "fa fa-hdd-o";
         if (hostname) {
           if (!agentGroups[hostname]) {
             agentGroups[hostname] = {
               text: hostname,
-              os: os,
-              ip: ip,
+              os: targetData.os,
+              ip: targetData.ip,
               children: [],
               isGroup: true,
               groupType: "agent",
@@ -249,81 +235,31 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
               expanded: true,
             };
           }
-          agentGroups[hostname].children.push({
-            ...targetData,
-            agent_hostname: hostname,
-            os: os,
-            ip: ip,
-            leaf: true,
-            isGroup: false,
-            iconCls: "fa fa-hdd-o",
-          });
+          agentGroups[hostname].children.push(treeNode);
         } else {
-          localTargets.push({
-            ...targetData,
-            leaf: true,
-            isGroup: false,
-            iconCls: "fa fa-hdd-o",
-          });
+          localTargets.push(treeNode);
         }
       } else if (targetData.target_type === "s3") {
-        s3Targets.push({
-          ...targetData,
-          leaf: true,
-          isGroup: false,
-          iconCls: "fa fa-cloud",
-        });
+        treeNode.iconCls = "fa fa-cloud";
+        s3Targets.push(treeNode);
       } else {
-        localTargets.push({
-          ...targetData,
-          leaf: true,
-          isGroup: false,
-          iconCls: "fa fa-folder",
-        });
+        treeNode.iconCls = "fa fa-folder";
+        localTargets.push(treeNode);
       }
     });
 
     let rootChildren = [];
-
     if (localTargets.length > 0) {
-      rootChildren.push({
-        text: "Local Targets",
-        children: localTargets,
-        isGroup: true,
-        groupType: "local",
-        iconCls: "fa fa-desktop",
-        expanded: true,
-      });
+      rootChildren.push({ text: "Local Targets", children: localTargets, isGroup: true, groupType: "local", iconCls: "fa fa-desktop", expanded: true });
     }
-
     if (Object.keys(agentGroups).length > 0) {
-      let agentRootNode = {
-        text: "Agent Targets",
-        children: Object.values(agentGroups),
-        isGroup: true,
-        groupType: "agent-root",
-        iconCls: "fa fa-sitemap",
-        expanded: true,
-      };
-      rootChildren.push(agentRootNode);
+      rootChildren.push({ text: "Agent Targets", children: Object.values(agentGroups), isGroup: true, groupType: "agent-root", iconCls: "fa fa-sitemap", expanded: true });
     }
-
     if (s3Targets.length > 0) {
-      rootChildren.push({
-        text: "S3 Targets",
-        children: s3Targets,
-        isGroup: true,
-        groupType: "s3",
-        iconCls: "fa fa-cloud",
-        expanded: true,
-      });
+      rootChildren.push({ text: "S3 Targets", children: s3Targets, isGroup: true, groupType: "s3", iconCls: "fa fa-cloud", expanded: true });
     }
 
-    view.setRootNode({
-      text: "Root",
-      expanded: true,
-      children: rootChildren,
-    });
+    view.setRootNode({ text: "Root", expanded: true, children: rootChildren });
   },
 
   reload: function () {
@@ -335,7 +271,7 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
     let view = me.getView();
 
     Ext.Ajax.request({
-      url: pbsPlusBaseUrl + "/api2/json/d2d/target",
+      url: pbsPlusBaseUrl + "/api2/json/d2d/target/tree",
       method: "GET",
       withCredentials: true,
       headers: {
@@ -343,17 +279,25 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
       },
       success: function (response) {
         let data = Ext.decode(response.responseText);
-        let rawTargets = data.data || [];
+        let treeNodes = data.data || [];
 
-        let targets = rawTargets.map((target) => {
-          return Ext.create("pbs-model-targets", target);
+        let rootChildren = treeNodes.map(function (node) {
+          return me.convertTreeNode(node);
+        });
+
+        view.setRootNode({
+          text: "Root",
+          expanded: true,
+          children: rootChildren,
         });
 
         // Store all targets for filtering
-        me.allTargetsData = targets;
-
-        // Apply current filter if exists
-        me.filterTree();
+        me.allTargetsData = [];
+        view.getRootNode().cascadeBy(function (node) {
+          if (!node.data.isGroup) {
+            me.allTargetsData.push(node);
+          }
+        });
 
         // Async: fetch detailed statuses
         me.loadStatuses();
@@ -362,6 +306,51 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
         Ext.Msg.alert(gettext("Error"), gettext("Failed to load targets"));
       },
     });
+  },
+
+  convertTreeNode: function (node) {
+    let result = {
+      text: node.text,
+      iconCls: node.iconCls,
+      expanded: node.expanded,
+      isGroup: node.isGroup,
+      groupType: node.groupType,
+      leaf: node.leaf,
+    };
+
+    if (!node.isGroup) {
+      Ext.apply(result, {
+        name: node.name,
+        path: node.path,
+        target_type: node.target_type,
+        mount_script: node.mount_script,
+        volume_id: node.volume_id,
+        job_count: node.job_count,
+        agent_version: node.agent_version,
+        connection_status: node.connection_status,
+        volume_type: node.volume_type,
+        volume_name: node.volume_name,
+        volume_fs: node.volume_fs,
+        volume_total_bytes: node.volume_total_bytes,
+        volume_used_bytes: node.volume_used_bytes,
+        volume_free_bytes: node.volume_free_bytes,
+        volume_total: node.volume_total || node.volume_total_human,
+        volume_used: node.volume_used || node.volume_used_human,
+        volume_free: node.volume_free || node.volume_free_human,
+        agent_hostname: node.agent_hostname,
+        os: node.os,
+        ip: node.ip,
+      });
+    }
+
+    if (node.children && node.children.length > 0) {
+      result.children = node.children.map(function (child) {
+        return me.convertTreeNode(child);
+      }.bind(this));
+      result.leaf = false;
+    }
+
+    return result;
   },
 
   loadStatuses: function () {
@@ -425,10 +414,7 @@ Ext.define("PBS.D2DManagement.TargetPanelController", {
     if (record.data.isGroup) {
       return "";
     }
-    if (!value && value !== 0) {
-      return "-";
-    }
-    return humanReadableBytes(value);
+    return value || "-";
   },
 
   render_field: function (value, metaData, record) {

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -202,6 +202,8 @@ Ext.define("PBS.D2DVerification.JobPanel", {
           }
 
           function renderFileStatus(v) {
+            // Use pre-computed status_human if available
+            if (typeof v === "object" && v.status_human) return v.status_human;
             switch (v) {
               case "ok":
                 return '<span style="color:green;">\u2713 OK</span>';
@@ -219,24 +221,24 @@ Ext.define("PBS.D2DVerification.JobPanel", {
           }
 
           function renderSize(bytes) {
+            if (typeof bytes === "string") return bytes || "-"; // already formatted
             if (!bytes && bytes !== 0) return "-";
             if (bytes < 1024) return bytes + " B";
             if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KiB";
-            if (bytes < 1073741824)
-              return (bytes / 1048576).toFixed(1) + " MiB";
+            if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + " MiB";
             return (bytes / 1073741824).toFixed(2) + " GiB";
           }
 
           function renderPassRate(rec) {
+            var pct = rec.get("pass_rate");
             var total = rec.get("total_files") || 0;
             var verified = rec.get("verified_files") || 0;
             var failed = rec.get("failed_files") || 0;
             if (total === 0) return "-";
-            var pct = Math.round((verified / total) * 100);
             if (failed > 0)
               return (
                 '<span style="color:red;">' +
-                pct +
+                pct.toFixed(0) +
                 "% (" +
                 verified +
                 "/" +
@@ -245,7 +247,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               );
             return (
               '<span style="color:green;">' +
-              pct +
+              pct.toFixed(0) +
               "% (" +
               verified +
               "/" +
@@ -254,53 +256,18 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             );
           }
 
-          function computeConfidence(population, sample, failures) {
-            if (sample <= 0 || failures >= sample) return { c95: 0, c99: 0 };
-            var n = sample;
-            var N = population > 0 ? population : n;
-            if (n > N) N = n;
-            if (failures === 0) {
-              var fpc = Math.sqrt((N - n) / N);
-              if (fpc < 0) fpc = 0;
-              return {
-                c95: Math.max(0, Math.min(100, (1 - 3.0 / n * fpc) * 100)),
-                c99: Math.max(0, Math.min(100, (1 - 4.6 / n * fpc) * 100)),
-              };
-            }
-            var pHat = 1 - failures / n;
-            return {
-              c95: Math.max(0, Math.min(100, wilsonLower(pHat, n, 1.96) * 100)),
-              c99: Math.max(0, Math.min(100, wilsonLower(pHat, n, 2.576) * 100)),
-            };
-          }
-
-          function wilsonLower(pHat, n, z) {
-            var denom = 1 + z * z / n;
-            var centre = pHat + z * z / (2 * n);
-            var spread = z * Math.sqrt(pHat * (1 - pHat) / n + z * z / (4 * n * n));
-            return (centre - spread) / denom;
-          }
-
           var runsStore = Ext.create("Ext.data.Store", {
             fields: [
-              "id",
-              "snapshot",
-              "snapshot_time",
-              "total_files",
-              "total_population",
-              "verified_files",
-              "failed_files",
-              "skipped_files",
-              "status",
-              "started_at",
-              "completed_at",
-              "details",
+              "id", "snapshot", "snapshot_time", "total_files", "total_population",
+              "verified_files", "failed_files", "skipped_files", "status",
+              "started_at", "completed_at", "details", "pass_rate",
+              "confidence", "duration_human",
             ],
             data: results,
           });
 
           var detailsStore = Ext.create("Ext.data.Store", {
-            fields: ["path", "size", "status", "message"],
+            fields: ["path", "size", "size_human", "status", "status_human", "message"],
             data: [],
           });
 
@@ -319,9 +286,11 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             columns: [
               {
                 text: gettext("Status"),
-                dataIndex: "status",
+                dataIndex: "status_human",
                 width: 100,
-                renderer: renderFileStatus,
+                renderer: function (v) {
+                  return v || "-";
+                },
               },
               {
                 text: gettext("File Path"),
@@ -331,11 +300,9 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               },
               {
                 text: gettext("Size"),
-                dataIndex: "size",
+                dataIndex: "size_human",
                 width: 100,
-                renderer: function (v) {
-                  return v > 0 ? renderSize(v) : "-";
-                },
+                renderer: function (v) { return v || "-"; },
               },
               {
                 text: gettext("Details"),
@@ -412,15 +379,9 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               },
               {
                 text: gettext("Duration"),
+                dataIndex: "duration_human",
                 width: 90,
-                renderer: function (v, md, rec) {
-                  var start = rec.get("started_at");
-                  var end = rec.get("completed_at");
-                  if (!start || !end) return "-";
-                  var secs = end - start;
-                  if (secs < 60) return secs + "s";
-                  return Math.floor(secs / 60) + "m " + (secs % 60) + "s";
-                },
+                renderer: function (v) { return v || "-"; },
               },
             ],
             listeners: {
@@ -441,7 +402,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                 var failed = rec.get("failed_files") || 0;
                 var skipped = rec.get("skipped_files") || 0;
                 var snap = Ext.String.htmlEncode(rec.get("snapshot") || "");
-                var conf = computeConfidence(population, total, failed);
+                var conf = rec.get("confidence") || { c95: 0, c99: 0 };
 
                 summaryPanel.removeAll();
                 summaryPanel.add({
@@ -458,9 +419,9 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                     '</tr>' +
                     '<tr>' +
                     '<td style="padding:2px 15px;" colspan="6">' +
-                    '<span style="color:#555;"><b>95% Confidence:</b> ≥' + conf.c95.toFixed(1) + '% intact</span>' +
+                    '<span style="color:#555;"><b>95% Confidence:</b> ≥' + (conf.c95 || 0).toFixed(1) + '% intact</span>' +
                     '&nbsp;&nbsp;&nbsp;' +
-                    '<span style="color:#555;"><b>99% Confidence:</b> ≥' + conf.c99.toFixed(1) + '% intact</span>' +
+                    '<span style="color:#555;"><b>99% Confidence:</b> ≥' + (conf.c99 || 0).toFixed(1) + '% intact</span>' +
                     '</td>' +
                     '</tr>' +
                     '</table>',

--- a/internal/server/web/views/custom/windows/backup.js
+++ b/internal/server/web/views/custom/windows/backup.js
@@ -39,13 +39,6 @@ var legacyXattrModes = Ext.create("Ext.data.Store", {
 Ext.define("PBS.D2DManagement.BackupJobInputPanel", {
   extend: "Proxmox.panel.InputPanel",
   xtype: "pbsD2DBackupInputPanel",
-
-  setValues: function (values) {
-    if (values.target && typeof values.target === "object") {
-      values.target = values.target.name;
-    }
-    this.callParent([values]);
-  },
 });
 
 Ext.define("PBS.D2DManagement.BackupJobEdit", {
@@ -120,19 +113,8 @@ Ext.define("PBS.D2DManagement.BackupJobEdit", {
 
     if (me.jobData) {
       let data = Ext.apply({}, me.jobData);
-      if (data.target && typeof data.target === "object") {
-        data.target = data.target.name;
-      }
       me.setValues(data);
     }
-
-    me.on("afterload", function (success, data) {
-      if (success && data && data.target && typeof data.target === "object") {
-        data.target = data.target.name;
-
-        me.setValues(data);
-      }
-    });
   },
 
   items: {

--- a/internal/server/web/views/custom/windows/restore.js
+++ b/internal/server/web/views/custom/windows/restore.js
@@ -1,13 +1,6 @@
 Ext.define("PBS.D2DManagement.RestoreJobInputPanel", {
   extend: "Proxmox.panel.InputPanel",
   xtype: "pbsD2DRestoreInputPanel",
-
-  setValues: function (values) {
-    if (values["dest-target"] && typeof values["dest-target"] === "object") {
-      values["dest-target"] = values["dest-target"].name;
-    }
-    this.callParent([values]);
-  },
 });
 
 var restoreModes = Ext.create("Ext.data.Store", {
@@ -124,24 +117,8 @@ Ext.define("PBS.D2DManagement.RestoreJobEdit", {
 
     if (me.jobData) {
       let data = Ext.apply({}, me.jobData);
-      if (data["dest-target"] && typeof data["dest-target"] === "object") {
-        data["dest-target"] = data["dest-target"].name;
-      }
       me.setValues(data);
     }
-
-    me.on("afterload", function (success, data) {
-      if (
-        success &&
-        data &&
-        data["dest-target"] &&
-        typeof data["dest-target"] === "object"
-      ) {
-        data["dest-target"] = data["dest-target"].name;
-
-        me.setValues(data);
-      }
-    });
   },
 
   items: {
@@ -152,13 +129,6 @@ Ext.define("PBS.D2DManagement.RestoreJobEdit", {
       {
         title: gettext("Options"),
         xtype: "pbsD2DRestoreInputPanel",
-        listeners: {
-          beforesetvalues: function (panel, values) {
-            if (values.target && typeof values.target === "object") {
-              values.target = values.target.name;
-            }
-          },
-        },
         onGetValues: function (values) {
           let me = this;
 

--- a/internal/server/web/views/pre/1_initialization.js
+++ b/internal/server/web/views/pre/1_initialization.js
@@ -29,38 +29,3 @@ function encodePathValue(path) {
   return encoded;
 }
 
-function humanReadableBytes(bytes) {
-  const KB = 1024;
-  const MB = KB * 1024;
-  const GB = MB * 1024;
-  const TB = GB * 1024;
-
-  if (bytes >= TB) {
-    return `${(bytes / TB).toFixed(2)} TB`;
-  } else if (bytes >= GB) {
-    return `${(bytes / GB).toFixed(2)} GB`;
-  } else if (bytes >= MB) {
-    return `${(bytes / MB).toFixed(2)} MB`;
-  } else if (bytes >= KB) {
-    return `${(bytes / KB).toFixed(2)} KB`;
-  } else {
-    return `${bytes} B`;
-  }
-}
-
-function humanReadableSpeed(speed) {
-  const KB = 1024.0;
-  const MB = KB * 1024;
-  const GB = MB * 1024;
-
-  if (speed >= GB) {
-    return `${(speed / GB).toFixed(2)} GB/s`;
-  } else if (speed >= MB) {
-    return `${(speed / MB).toFixed(2)} MB/s`;
-  } else if (speed >= KB) {
-    return `${(speed / KB).toFixed(2)} KB/s`;
-  } else {
-    return `${speed.toFixed(2)} B/s`;
-  }
-}
-

--- a/internal/server/web/views/pre/1_initialization.js
+++ b/internal/server/web/views/pre/1_initialization.js
@@ -2,25 +2,6 @@ const pbsFullUrl = window.location.href;
 const pbsUrl = new URL(pbsFullUrl);
 const pbsPlusBaseUrl = `${pbsUrl.protocol}//${pbsUrl.hostname}:8017`;
 
-function getCookie(cName) {
-  const name = cName + "=";
-  const cDecoded = decodeURIComponent(document.cookie);
-  const cArr = cDecoded.split('; ');
-  let res;
-  cArr.forEach(val => {
-    if (val.indexOf(name) === 0) res = val.substring(name.length);
-  })
-  return res
-}
-
-var pbsPlusTokenHeaders = {
-  "Content-Type": "application/json",
-};
-
-if (Proxmox.CSRFPreventionToken) {
-  pbsPlusTokenHeaders["Csrfpreventiontoken"] = Proxmox.CSRFPreventionToken;
-}
-
 function encodePathValue(path) {
   const encoded = btoa(path)
     .replace(/\+/g, '-')

--- a/internal/server/web/views/pre/2_utils.js
+++ b/internal/server/web/views/pre/2_utils.js
@@ -185,32 +185,25 @@ Ext.define("PBS.PlusUtils", {
       return "";
     }
 
+    // Use pre-parsed status from backend if available
+    let parsed = record.get("status_parsed");
+    if (parsed && parsed.icon) {
+      return `<i class="fa fa-${parsed.icon}"></i> ${parsed.text}`;
+    }
+
+    // Fallback: parse client-side for backward compat
     let parse_task_status = function (status) {
-      if (status === "OK") {
-        return "ok";
-      }
-
-      if (status === "unknown") {
-        return "unknown";
-      }
-
-      let match = status.match(/^WARNINGS: (.*)$/);
-      if (match) {
-        return "warning";
-      }
-
-      match = status.match(/^QUEUED: (.*)$/);
-      if (match) {
-        return "queued";
-      }
-
+      if (status === "OK") return "ok";
+      if (status === "unknown") return "unknown";
+      if (status && status.match(/^WARNINGS: /)) return "warning";
+      if (status && status.match(/^QUEUED: /)) return "queued";
       return "error";
     };
 
-    let parsed = parse_task_status(value);
+    let category = parse_task_status(value);
     let text = value;
     let icon = "";
-    switch (parsed) {
+    switch (category) {
       case "unknown":
         icon = "question faded";
         text = Proxmox.Utils.unknownText;

--- a/internal/server/web/views/pre/2_utils.js
+++ b/internal/server/web/views/pre/2_utils.js
@@ -185,46 +185,12 @@ Ext.define("PBS.PlusUtils", {
       return "";
     }
 
-    // Use pre-parsed status from backend if available
     let parsed = record.get("status_parsed");
     if (parsed && parsed.icon) {
       return `<i class="fa fa-${parsed.icon}"></i> ${parsed.text}`;
     }
 
-    // Fallback: parse client-side for backward compat
-    let parse_task_status = function (status) {
-      if (status === "OK") return "ok";
-      if (status === "unknown") return "unknown";
-      if (status && status.match(/^WARNINGS: /)) return "warning";
-      if (status && status.match(/^QUEUED: /)) return "queued";
-      return "error";
-    };
-
-    let category = parse_task_status(value);
-    let text = value;
-    let icon = "";
-    switch (category) {
-      case "unknown":
-        icon = "question faded";
-        text = Proxmox.Utils.unknownText;
-        break;
-      case "error":
-        icon = "times critical";
-        text = Proxmox.Utils.errorText + ": " + value;
-        break;
-      case "warning":
-        icon = "exclamation warning";
-        break;
-      case "ok":
-        icon = "check good";
-        text = gettext("OK");
-        break;
-      case "queued":
-        icon = "tasks faded";
-        break;
-    }
-
-    return `<i class="fa fa-${icon}"></i> ${text}`;
+    return "-";
   },
 });
 
@@ -404,7 +370,7 @@ Ext.define("PBS.plusWindow.Edit", {
 });
 
 Ext.define("PBS.plusWindow.Create", {
-  extend: "Proxmox.window.Edit",
+  extend: "PBS.plusWindow.Edit",
   alias: "widget.pbsPlusWindowCreate",
 
   method: "POST",
@@ -413,80 +379,5 @@ Ext.define("PBS.plusWindow.Create", {
     let me = this;
     let form = me.formPanel.getForm();
     form.clearInvalid();
-  },
-
-  submit: function () {
-    let me = this;
-    let form = me.formPanel.getForm();
-    let values = me.getValues();
-
-    Ext.Object.each(values, function (name, val) {
-      if (Object.hasOwn(values, name)) {
-        if (Ext.isArray(val) && !val.length) {
-          values[name] = "";
-        }
-      }
-    });
-
-    if (me.digest) {
-      values.digest = me.digest;
-    }
-
-    if (me.backgroundDelay) {
-      values.background_delay = me.backgroundDelay;
-    }
-
-    let url = Ext.isFunction(me.submitUrl)
-      ? me.submitUrl(me.url, values)
-      : me.submitUrl || me.url;
-
-    if (me.method === "DELETE") {
-      url = url + "?" + Ext.Object.toQueryString(values);
-      values = undefined;
-    }
-
-    let requestOptions = Ext.apply(
-      {
-        url: url,
-        waitMsgTarget: me,
-        method: me.method || "POST",
-        params: values,
-        failure: function (response, options) {
-          me.apiCallDone(false, response, options);
-          if (response.result && response.result.errors) {
-            form.markInvalid(response.result.errors);
-          }
-          Ext.Msg.alert(gettext("Error"), response.htmlStatus);
-        },
-        success: function (response, options) {
-          let hasProgressBar =
-            (me.backgroundDelay || me.showProgress || me.showTaskViewer) &&
-            response.result.data;
-
-          me.apiCallDone(true, response, options);
-
-          if (hasProgressBar) {
-            me.hide();
-            let upid = response.result.data;
-            let viewerClass = me.showTaskViewer ? "Viewer" : "Progress";
-            Ext.create("Proxmox.window.Task" + viewerClass, {
-              autoShow: true,
-              upid: upid,
-              taskDone: me.taskDone,
-              listeners: {
-                destroy: function () {
-                  me.close();
-                },
-              },
-            });
-          } else {
-            me.close();
-          }
-        },
-      },
-      me.submitOptions ?? {},
-    );
-
-    PBS.PlusUtils.API2Request(requestOptions);
   },
 });


### PR DESCRIPTION
## Summary

Moves all business logic from JS frontend to Go backend, then removes dead code and deduplicates.

### Backend (new)
- Pre-formatted fields (`*_human` pattern) for bytes, speed, duration, status
- Pre-parsed task status (`status_parsed` with icon/text)
- Pre-computed verification confidence (Wilson score intervals)
- Pre-built target tree endpoint (`/api2/json/d2d/target/tree`)
- Server-side CSV export endpoint
- Flat response types (`FlatBackup`, `FlatRestore`, `FlatVerificationJob`, `FlatVerificationResult`, `TargetTreeNode`)

### Frontend (removed)
- `humanReadableBytes`, `humanReadableSpeed` from initialization
- All `reader.transform` functions from models
- `buildTree()`, `computeConfidence()`, `wilsonLower()` from panels
- Client-side task status parsing fallback
- Dead `getCookie()`, `pbsPlusTokenHeaders`
- Duplicate `plusWindow.Create.submit()` (now extends `plusWindow.Edit`)

### Dead code removed
- 3 unused flat endpoint handlers and routes
- 4 unused response types
- Duplicate `computeConfidence`/`wilsonLower`/`clamp01` (consolidated into `format.go`)
- Duplicate CSV escape function

### Fixes
- Deterministic sort order for target tree (agent groups sorted by hostname)

**17 files changed, +1162/-751 lines**