### PR TITLE
feat(verification): dashboard, pass/fail badges, namespace fallback

### DIFF
--- a/internal/server/application/services.go
+++ b/internal/server/application/services.go
@@ -354,3 +354,20 @@ func (s *VerificationService) CreateVerificationResult(r *database.VerificationR
 func (s *VerificationService) UpdateVerificationResult(r database.VerificationResult) error {
 	return s.db.UpdateVerificationResult(r)
 }
+
+// GetAllVerificationResults returns results from all verification jobs.
+func (s *VerificationService) GetAllVerificationResults() ([]database.VerificationResult, error) {
+	jobs, err := s.db.GetAllVerificationJobs()
+	if err != nil {
+		return nil, err
+	}
+	var all []database.VerificationResult
+	for _, j := range jobs {
+		results, err := s.db.GetVerificationResults(j.ID)
+		if err != nil {
+			continue
+		}
+		all = append(all, results...)
+	}
+	return all, nil
+}

--- a/internal/server/verification/job.go
+++ b/internal/server/verification/job.go
@@ -449,8 +449,19 @@ func (v *verificationJob) execute(ctx context.Context) error {
 
 		vTask.WriteString(fmt.Sprintf("selected backup job '%s', snapshot: %s", backup.ID, snapshot.Snapshot))
 
-		// All startup checks passed — run verification for this snapshot
-		return v.executeVerification(ctx, vTask, job, backup, snapshot, vs, agentTCP)
+		// Run verification for this snapshot
+		err := v.executeVerification(ctx, vTask, job, backup, snapshot, vs, agentTCP)
+		if err == nil {
+			return nil
+		}
+
+		// In namespace mode, if no files could be sampled, try the next backup job
+		if errors.Is(err, ErrNoFilesToVerify) && job.TargetMode == "namespace" {
+			vTask.WriteString(fmt.Sprintf("skipping backup job '%s': no eligible files found, trying next candidate", backup.ID))
+			lastStartupErr = err
+			continue
+		}
+		return err
 	}
 
 	// All candidates exhausted
@@ -503,6 +514,8 @@ func (v *verificationJob) executeVerification(
 	// Enumerate files from the pxar archive and sample
 	sampledFiles, err := v.sampleFiles(ctx, job, vs, snapshot)
 	if err != nil {
+		// Mark the stale result as skipped so we don't leave orphaned "running" records
+		_ = v.storeInstance.Database.MarkVerificationResultStatus(result.ID, "skipped", time.Now().Unix())
 		return fmt.Errorf("failed to sample files: %w", err)
 	}
 

--- a/internal/server/web/api/flatten.go
+++ b/internal/server/web/api/flatten.go
@@ -228,6 +228,16 @@ func FlattenVerificationResult(r database.VerificationResult) FlatVerificationRe
 		Confidence:        ComputeConfidence(r.TotalPopulation, r.TotalFiles, r.FailedFiles),
 	}
 
+	// Status badge: pass/fail semantics
+	switch {
+	case r.Status == "OK" && r.FailedFiles == 0:
+		fr.StatusBadge = "passed"
+	case r.FailedFiles > 0:
+		fr.StatusBadge = "failed"
+	default:
+		fr.StatusBadge = "warning"
+	}
+
 	// Duration
 	if r.StartedAt > 0 && r.CompletedAt > r.StartedAt {
 		secs := r.CompletedAt - r.StartedAt

--- a/internal/server/web/api/flatten.go
+++ b/internal/server/web/api/flatten.go
@@ -87,6 +87,7 @@ func FlattenRestore(r database.Restore) FlatRestore {
 		Store:         r.Store,
 		Namespace:     r.Namespace,
 		Snapshot:      r.Snapshot,
+		SnapshotHuman: formatSnapshotLabel(r.Snapshot, r.Namespace),
 		SrcPath:       r.SrcPath,
 		DestSubpath:   r.DestSubpath,
 		PreScript:     r.PreScript,
@@ -210,13 +211,14 @@ func FlattenVerificationJobs(jobs []database.VerificationJob) []FlatVerification
 }
 
 // FlattenVerificationResult converts a VerificationResult with pre-computed display fields.
-func FlattenVerificationResult(r database.VerificationResult) FlatVerificationResult {
+func FlattenVerificationResult(r database.VerificationResult, namespace string) FlatVerificationResult {
 	fr := FlatVerificationResult{
 		ID:                r.ID,
 		VerificationJobID: r.VerificationJobID,
 		UPID:              r.UPID,
 		Snapshot:          r.Snapshot,
 		SnapshotTime:      r.SnapshotTime,
+		SnapshotHuman:     formatSnapshotLabel(r.Snapshot, namespace),
 		TotalPopulation:   r.TotalPopulation,
 		TotalFiles:        r.TotalFiles,
 		VerifiedFiles:     r.VerifiedFiles,
@@ -265,12 +267,20 @@ func FlattenVerificationResult(r database.VerificationResult) FlatVerificationRe
 }
 
 // FlattenVerificationResults converts a slice of verification results.
-func FlattenVerificationResults(results []database.VerificationResult) []FlatVerificationResult {
+func FlattenVerificationResults(results []database.VerificationResult, namespace string) []FlatVerificationResult {
 	fr := make([]FlatVerificationResult, len(results))
 	for i := range results {
-		fr[i] = FlattenVerificationResult(results[i])
+		fr[i] = FlattenVerificationResult(results[i], namespace)
 	}
 	return fr
+}
+
+// formatSnapshotLabel produces a human-readable snapshot label that includes the namespace.
+func formatSnapshotLabel(snapshot, namespace string) string {
+	if namespace == "" || namespace == "root" {
+		return snapshot
+	}
+	return namespace + ": " + snapshot
 }
 
 // BuildTargetTree groups targets into a tree structure by type (local/agent/s3).

--- a/internal/server/web/api/format.go
+++ b/internal/server/web/api/format.go
@@ -3,6 +3,9 @@ package api
 import (
 	"fmt"
 	"math"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/server/database"
 )
 
 // HumanReadableBytes converts bytes to a human-readable string (e.g. "1.50 GiB").
@@ -185,6 +188,41 @@ func clamp01(v float64) float64 {
 }
 
 // FormatSpeed returns "X.XX files/s" string.
+// ComputeAggregate computes verification summary statistics across all results.
+func ComputeAggregate(results []database.VerificationResult) VerificationAggregate {
+	var agg VerificationAggregate
+	thirtyDaysAgo := time.Now().Unix() - 30*24*3600
+
+	for _, r := range results {
+		if r.Status == "" || r.Status == "pending" {
+			continue // skip incomplete runs
+		}
+		agg.TotalRuns++
+		agg.TotalFiles += r.TotalFiles
+		agg.TotalFailed += r.FailedFiles
+		agg.TotalSkipped += r.SkippedFiles
+
+		if r.FailedFiles == 0 && r.Status == "OK" {
+			agg.CleanRuns++
+		} else if r.FailedFiles > 0 {
+			agg.FailedRuns++
+		}
+
+		if r.StartedAt >= thirtyDaysAgo {
+			agg.Last30Days++
+		}
+	}
+
+	if agg.TotalFiles > 0 {
+		agg.PassRate = float64(agg.TotalFiles-agg.TotalFailed) / float64(agg.TotalFiles) * 100
+	}
+
+	// Aggregate confidence: treat all samples as one big test
+	agg.Confidence = ComputeConfidence(0, agg.TotalFiles, agg.TotalFailed).Confidence95
+
+	return agg
+}
+
 func FormatSpeed(speed int) string {
 	return fmt.Sprintf("%.2f files/s", float64(speed))
 }

--- a/internal/server/web/api/types.go
+++ b/internal/server/web/api/types.go
@@ -62,6 +62,7 @@ type FlatRestore struct {
 	Store         string `json:"store"`
 	Namespace     string `json:"ns"`
 	Snapshot      string `json:"snapshot"`
+	SnapshotHuman string `json:"snapshot_human"`
 	SrcPath       string `json:"src-path"`
 	DestSubpath   string `json:"dest-subpath"`
 	PreScript     string `json:"pre_script"`
@@ -167,6 +168,7 @@ type FlatVerificationResult struct {
 	VerificationJobID string                       `json:"verification_job_id"`
 	UPID              string                       `json:"upid"`
 	Snapshot          string                       `json:"snapshot"`
+	SnapshotHuman     string                       `json:"snapshot_human"`
 	SnapshotTime      int64                        `json:"snapshot_time"`
 	TotalPopulation   int                          `json:"total_population"`
 	TotalFiles        int                          `json:"total_files"`

--- a/internal/server/web/api/types.go
+++ b/internal/server/web/api/types.go
@@ -147,6 +147,20 @@ type SpotCheckFilterJSON struct {
 	MaxSize     int64  `json:"max_size"`
 }
 
+// VerificationAggregate holds summary statistics across all verification jobs.
+type VerificationAggregate struct {
+	TotalJobs    int     `json:"total_jobs"`
+	TotalRuns    int     `json:"total_runs"`
+	TotalFiles   int     `json:"total_files"`
+	TotalFailed  int     `json:"total_failed"`
+	TotalSkipped int     `json:"total_skipped"`
+	PassRate     float64 `json:"pass_rate"`  // percentage 0-100
+	CleanRuns    int     `json:"clean_runs"` // runs with zero failures
+	FailedRuns   int     `json:"failed_runs"`
+	Last30Days   int     `json:"last_30_days"` // runs in last 30 days
+	Confidence   float64 `json:"confidence"`   // aggregate 95% CI lower bound
+}
+
 // FlatVerificationResult extends VerificationResult with pre-computed display fields.
 type FlatVerificationResult struct {
 	ID                int                          `json:"id"`
@@ -165,6 +179,7 @@ type FlatVerificationResult struct {
 	DurationHuman     string                       `json:"duration_human"`
 	PassRate          float64                      `json:"pass_rate"` // percentage 0-100
 	Confidence        ConfidenceInfo               `json:"confidence"`
+	StatusBadge       string                       `json:"status_badge"` // "passed" | "failed" | "warning"
 	Details           []FlatVerificationFileResult `json:"details"`
 }
 

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -539,7 +539,13 @@ func ExtJsVerificationResultsHandler(storeInstance *store.Store) http.HandlerFun
 			return
 		}
 
-		flatResults := FlattenVerificationResults(results)
+		job, err := storeInstance.VerificationSvc.GetVerificationJob(jobID)
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		flatResults := FlattenVerificationResults(results, job.Namespace)
 
 		response := map[string]any{
 			"status":  http.StatusOK,

--- a/internal/server/web/api/verification_handlers.go
+++ b/internal/server/web/api/verification_handlers.go
@@ -483,6 +483,40 @@ func ExtJsVerificationConfigSingleHandler(storeInstance *store.Store) http.Handl
 	}
 }
 
+// VerificationAggregateHandler returns aggregate stats across all verification jobs.
+func VerificationAggregateHandler(storeInstance *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		results, err := storeInstance.VerificationSvc.GetAllVerificationResults()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		jobs, err := storeInstance.VerificationSvc.ListVerificationJobs()
+		if err != nil {
+			WriteErrorResponse(w, err)
+			return
+		}
+
+		agg := ComputeAggregate(results)
+		agg.TotalJobs = len(jobs)
+
+		response := map[string]any{
+			"status":  http.StatusOK,
+			"success": true,
+			"data":    agg,
+		}
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
 // ExtJsVerificationResultsHandler returns verification results for a job.
 func ExtJsVerificationResultsHandler(storeInstance *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/web/server.go
+++ b/internal/server/web/server.go
@@ -83,6 +83,7 @@ func NewServer(storeInstance *store.Store, version string) (*Server, error) {
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification/{id}", ServerOnly(storeInstance, api.ExtJsVerificationConfigSingleHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification/{id}/results", ServerOnly(storeInstance, api.ExtJsVerificationResultsHandler(storeInstance)))
 	apiMux.HandleFunc("/api2/extjs/config/d2d-verification/{id}/results/export", ServerOnly(storeInstance, api.VerificationResultsExportHandler(storeInstance)))
+	apiMux.HandleFunc("/api2/json/d2d/verification/aggregate", ServerOnly(storeInstance, api.VerificationAggregateHandler(storeInstance)))
 	apiMux.HandleFunc("/plus/metrics", api.PrometheusMetricsHandler(storeInstance))
 
 	// Agent routes

--- a/internal/server/web/views/custom/panels/restores.js
+++ b/internal/server/web/views/custom/panels/restores.js
@@ -415,7 +415,7 @@ Ext.define("PBS.config.DiskRestoreJobView", {
     },
     {
       header: gettext("Snapshot"),
-      dataIndex: "snapshot",
+      dataIndex: "snapshot_human",
       width: 120,
       sortable: true,
     },

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -12,6 +12,22 @@ Ext.define("PBS.D2DVerification.JobPanel", {
     {
       xtype: "component",
       dock: "top",
+      cls: "x-fieldset",
+      style: {
+        padding: "8px 12px",
+        margin: "0 0 2px 0",
+        fontSize: "11px",
+        lineHeight: "15px",
+        color: "#555",
+      },
+      html:
+        "Periodically verify that backed-up files can be restored without corruption. " +
+        "Each job samples files from a snapshot and checks their integrity against the source agent. " +
+        "Use the results to demonstrate backup reliability over time.",
+    },
+    {
+      xtype: "component",
+      dock: "top",
       reference: "aggregateBar",
       hidden: true,
       cls: "x-fieldset",
@@ -475,6 +491,20 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             },
           });
 
+          var descPanel = Ext.create("Ext.panel.Panel", {
+            layout: "fit",
+            margin: "0 0 5 0",
+            items: [{
+              xtype: "component",
+              html:
+                '<span style="color:#555;font-size:11px;">' +
+                "Each row is one verification run. Select a run to see file-level details. " +
+                "The confidence values indicate the statistical lower bound on the percentage " +
+                "of intact files in the snapshot, based on the sample size and results." +
+                '</span>',
+            }],
+          });
+
           Ext.create("Ext.window.Window", {
             title:
               gettext("Verification Results: ") +
@@ -486,7 +516,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               type: "vbox",
               align: "stretch",
             },
-            items: [summaryPanel, runsGrid, detailsGrid],
+            items: [descPanel, summaryPanel, runsGrid, detailsGrid],
             buttons: [
               {
                 text: gettext("Export Detail CSV"),

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -7,6 +7,24 @@ Ext.define("PBS.D2DVerification.JobPanel", {
   selType: "checkboxmodel",
   multiSelect: true,
 
+  // Aggregate stats bar shown above the grid
+  dockedItems: [
+    {
+      xtype: "component",
+      dock: "top",
+      reference: "aggregateBar",
+      hidden: true,
+      cls: "x-fieldset",
+      style: {
+        padding: "8px 12px",
+        margin: "0 0 4px 0",
+        fontSize: "12px",
+        lineHeight: "18px",
+      },
+      html: "Loading...",
+    },
+  ],
+
   controller: {
     xclass: "Ext.app.ViewController",
 
@@ -327,6 +345,23 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             store: runsStore,
             columns: [
               {
+                text: gettext("Result"),
+                dataIndex: "status_badge",
+                width: 80,
+                renderer: function (v) {
+                  switch (v) {
+                    case "passed":
+                      return '<span style="color:green;font-weight:bold;">\u2713 Passed</span>';
+                    case "failed":
+                      return '<span style="color:red;font-weight:bold;">\u2717 Failed</span>';
+                    case "warning":
+                      return '<span style="color:#c93;">\u26A0 Warning</span>';
+                    default:
+                      return '<span style="color:#888;">' + Ext.String.htmlEncode(v || "-") + '</span>';
+                  }
+                },
+              },
+              {
                 text: gettext("Snapshot"),
                 dataIndex: "snapshot",
                 flex: 2,
@@ -422,6 +457,10 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                     '<span style="color:#555;"><b>95% Confidence:</b> ≥' + (conf.c95 || 0).toFixed(1) + '% intact</span>' +
                     '&nbsp;&nbsp;&nbsp;' +
                     '<span style="color:#555;"><b>99% Confidence:</b> ≥' + (conf.c99 || 0).toFixed(1) + '% intact</span>' +
+                    '&nbsp;&nbsp;&nbsp;' +
+                    '<span style="font-weight:bold;color:' + (failed > 0 ? 'red' : 'green') + ';">' +
+                    (failed > 0 ? '\u2717 FAIL — ' + failed + ' file(s) failed verification' : '\u2713 PASS — all sampled files verified successfully') +
+                    '</span>' +
                     '</td>' +
                     '</tr>' +
                     '</table>',
@@ -525,6 +564,50 @@ Ext.define("PBS.D2DVerification.JobPanel", {
 
     startStore: function () {
       this.getView().getStore().rstore.startUpdate();
+      this.loadAggregate();
+    },
+
+    loadAggregate: function () {
+      var me = this;
+      PBS.PlusUtils.API2Request({
+        url: "/api2/json/d2d/verification/aggregate",
+        method: "GET",
+        success: function (response) {
+          var data = response.result.data;
+          if (!data) return;
+          var bar = me.getView().down("[reference=aggregateBar]");
+          if (!bar) return;
+
+          var totalRuns = data.total_runs || 0;
+          var totalFiles = data.total_files || 0;
+          var totalFailed = data.total_failed || 0;
+          var cleanRuns = data.clean_runs || 0;
+          var failedRuns = data.failed_runs || 0;
+          var last30 = data.last_30_days || 0;
+          var passRate = data.pass_rate || 0;
+          var confidence = data.confidence || 0;
+
+          if (totalRuns === 0) {
+            bar.hide();
+            return;
+          }
+
+          bar.show();
+          var html =
+            '<table style="width:100%;"><tr>' +
+            '<td style="padding:2px 20px;"><b>Total Runs:</b> ' + totalRuns + '</td>' +
+            '<td style="padding:2px 20px;"><b>Files Verified:</b> ' + totalFiles.toLocaleString() + '</td>' +
+            '<td style="padding:2px 20px;color:green;"><b>Clean Runs:</b> ' + cleanRuns + ' \u2713</td>' +
+            '<td style="padding:2px 20px;color:' + (failedRuns > 0 ? 'red' : '#888') + ';"><b>Failed Runs:</b> ' + failedRuns + (failedRuns > 0 ? ' \u2717' : '') + '</td>' +
+            '</tr><tr>' +
+            '<td style="padding:2px 20px;"><b>Last 30 Days:</b> ' + last30 + ' runs</td>' +
+            '<td style="padding:2px 20px;"><b>Overall Pass Rate:</b> ' + passRate.toFixed(1) + '%</td>' +
+            '<td style="padding:2px 20px;"><b>95% Confidence:</b> ≥' + confidence.toFixed(1) + '% intact</td>' +
+            '<td style="padding:2px 20px;color:#888;"><b>Jobs Configured:</b> ' + (data.total_jobs || 0) + '</td>' +
+            '</tr></table>';
+          bar.setHtml(html);
+        },
+      });
     },
 
     stopStore: function () {
@@ -704,6 +787,18 @@ Ext.define("PBS.D2DVerification.JobPanel", {
       renderer: PBS.Utils.render_optional_timestamp,
       width: 140,
       sortable: true,
+    },
+    {
+      header: gettext("Last Result"),
+      width: 90,
+      sortable: true,
+      renderer: function (v, md, rec) {
+        var state = rec.get("last-run-state") || "";
+        if (state === "OK") return '<span style="color:green;font-weight:bold;">\u2713 Passed</span>';
+        if (state && state.startsWith("WARN")) return '<span style="color:#c93;">\u26A0 Warning</span>';
+        if (state && state !== "") return '<span style="color:red;">\u2717 Failed</span>';
+        return '<span style="color:#888;">-</span>';
+      },
     },
     {
       header: gettext("Status"),

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -12,13 +12,12 @@ Ext.define("PBS.D2DVerification.JobPanel", {
     {
       xtype: "component",
       dock: "top",
-      cls: "x-fieldset",
+      cls: "pmx-hint",
       style: {
         padding: "8px 12px",
         margin: "0 0 2px 0",
         fontSize: "11px",
         lineHeight: "15px",
-        color: "#555",
       },
       html:
         "Periodically verify that backed-up files can be restored without corruption. " +
@@ -244,7 +243,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               case "failed":
                 return '<span style="color:red;">\u2717 Failed</span>';
               case "skipped":
-                return '<span style="color:#888;">\u25CB Skipped</span>';
+                return '<span style="opacity:0.7;">\u25CB Skipped</span>';
               case "warning":
                 return '<span style="color:#c93;">\u26A0 Warning</span>';
               case "error":
@@ -373,7 +372,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                     case "warning":
                       return '<span style="color:#c93;">\u26A0 Warning</span>';
                     default:
-                      return '<span style="color:#888;">' + Ext.String.htmlEncode(v || "-") + '</span>';
+                      return '<span style="opacity:0.7;">' + Ext.String.htmlEncode(v || "-") + '</span>';
                   }
                 },
               },
@@ -465,14 +464,14 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                     '<td style="padding:2px 15px;"><b>Population:</b> ' + (population || '-') + '</td>' +
                     '<td style="padding:2px 15px;"><b>Sampled:</b> ' + total + '</td>' +
                     '<td style="padding:2px 15px;color:green;"><b>Verified:</b> ' + verified + '</td>' +
-                    '<td style="padding:2px 15px;color:' + (failed > 0 ? 'red' : '#888') + ';"><b>Failed:</b> ' + failed + '</td>' +
-                    '<td style="padding:2px 15px;color:#888;"><b>Skipped:</b> ' + skipped + '</td>' +
+                    '<td style="padding:2px 15px;color:' + (failed > 0 ? 'red' : 'inherit') + ';"><b>Failed:</b> ' + failed + '</td>' +
+                    '<td style="padding:2px 15px;opacity:0.7;"><b>Skipped:</b> ' + skipped + '</td>' +
                     '</tr>' +
                     '<tr>' +
                     '<td style="padding:2px 15px;" colspan="6">' +
-                    '<span style="color:#555;"><b>95% Confidence:</b> ≥' + (conf.c95 || 0).toFixed(1) + '% intact</span>' +
+                    '<span><b>95% Confidence:</b> ≥' + (conf.c95 || 0).toFixed(1) + '% intact</span>' +
                     '&nbsp;&nbsp;&nbsp;' +
-                    '<span style="color:#555;"><b>99% Confidence:</b> ≥' + (conf.c99 || 0).toFixed(1) + '% intact</span>' +
+                    '<span><b>99% Confidence:</b> ≥' + (conf.c99 || 0).toFixed(1) + '% intact</span>' +
                     '&nbsp;&nbsp;&nbsp;' +
                     '<span style="font-weight:bold;color:' + (failed > 0 ? 'red' : 'green') + ';">' +
                     (failed > 0 ? '\u2717 FAIL — ' + failed + ' file(s) failed verification' : '\u2713 PASS — all sampled files verified successfully') +
@@ -497,7 +496,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             items: [{
               xtype: "component",
               html:
-                '<span style="color:#555;font-size:11px;">' +
+                '<span class="pmx-hint" style="display:block;padding:4px 6px;font-size:11px;">' +
                 "Each row is one verification run. Select a run to see file-level details. " +
                 "The confidence values indicate the statistical lower bound on the percentage " +
                 "of intact files in the snapshot, based on the sample size and results." +
@@ -628,12 +627,12 @@ Ext.define("PBS.D2DVerification.JobPanel", {
             '<td style="padding:2px 20px;"><b>Total Runs:</b> ' + totalRuns + '</td>' +
             '<td style="padding:2px 20px;"><b>Files Verified:</b> ' + totalFiles.toLocaleString() + '</td>' +
             '<td style="padding:2px 20px;color:green;"><b>Clean Runs:</b> ' + cleanRuns + ' \u2713</td>' +
-            '<td style="padding:2px 20px;color:' + (failedRuns > 0 ? 'red' : '#888') + ';"><b>Failed Runs:</b> ' + failedRuns + (failedRuns > 0 ? ' \u2717' : '') + '</td>' +
+            '<td style="padding:2px 20px;color:' + (failedRuns > 0 ? 'red' : 'inherit') + ';"><b>Failed Runs:</b> ' + failedRuns + (failedRuns > 0 ? ' \u2717' : '') + '</td>' +
             '</tr><tr>' +
             '<td style="padding:2px 20px;"><b>Last 30 Days:</b> ' + last30 + ' runs</td>' +
             '<td style="padding:2px 20px;"><b>Overall Pass Rate:</b> ' + passRate.toFixed(1) + '%</td>' +
             '<td style="padding:2px 20px;"><b>95% Confidence:</b> ≥' + confidence.toFixed(1) + '% intact</td>' +
-            '<td style="padding:2px 20px;color:#888;"><b>Jobs Configured:</b> ' + (data.total_jobs || 0) + '</td>' +
+            '<td style="padding:2px 20px;"><b>Jobs Configured:</b> ' + (data.total_jobs || 0) + '</td>' +
             '</tr></table>';
           bar.setHtml(html);
         },
@@ -827,7 +826,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
         if (state === "OK") return '<span style="color:green;font-weight:bold;">\u2713 Passed</span>';
         if (state && state.startsWith("WARN")) return '<span style="color:#c93;">\u26A0 Warning</span>';
         if (state && state !== "") return '<span style="color:red;">\u2717 Failed</span>';
-        return '<span style="color:#888;">-</span>';
+        return '<span style="opacity:0.7;">-</span>';
       },
     },
     {

--- a/internal/server/web/views/custom/panels/verifications.js
+++ b/internal/server/web/views/custom/panels/verifications.js
@@ -53,6 +53,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
           return (
             re.test(rec.get("id")) ||
             re.test(rec.get("backup_job_id")) ||
+            re.test(rec.get("ns")) ||
             re.test(rec.get("mode")) ||
             re.test(rec.get("comment"))
           );
@@ -378,7 +379,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
               },
               {
                 text: gettext("Snapshot"),
-                dataIndex: "snapshot",
+                dataIndex: "snapshot_human",
                 flex: 2,
                 renderer: Ext.String.htmlEncode,
               },
@@ -451,7 +452,7 @@ Ext.define("PBS.D2DVerification.JobPanel", {
                 var verified = rec.get("verified_files") || 0;
                 var failed = rec.get("failed_files") || 0;
                 var skipped = rec.get("skipped_files") || 0;
-                var snap = Ext.String.htmlEncode(rec.get("snapshot") || "");
+                var snap = Ext.String.htmlEncode(rec.get("snapshot_human") || rec.get("snapshot") || "");
                 var conf = rec.get("confidence") || { c95: 0, c99: 0 };
 
                 summaryPanel.removeAll();
@@ -774,10 +775,18 @@ Ext.define("PBS.D2DVerification.JobPanel", {
       sortable: true,
     },
     {
-      header: gettext("Backup Job"),
+      header: gettext("Target"),
       dataIndex: "backup_job_id",
       width: 150,
       sortable: true,
+      renderer: function (v, md, rec) {
+        var mode = rec.get("target_mode");
+        var ns = rec.get("ns");
+        if (mode === "namespace") {
+          return ns && ns !== "root" ? ns : "/";
+        }
+        return Ext.String.htmlEncode(v || "-");
+      },
     },
     {
       header: gettext("Mode"),

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -428,7 +428,7 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       name: "sample_count",
       minValue: 1,
       maxValue: 100000,
-      value: 10,
+      value: 60,
       allowBlank: false,
     },
     {

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -207,6 +207,15 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
 
   column1: [
     {
+      xtype: "component",
+      html:
+        '<span style="color:#555;font-size:11px;">' +
+        "Configure which backup snapshots to verify and how often to run checks. " +
+        "Each run samples files from a snapshot and validates their integrity." +
+        '</span>',
+      margin: "0 0 8 0",
+    },
+    {
       xtype: "pmxDisplayEditField",
       name: "id",
       fieldLabel: gettext("Job ID"),
@@ -228,6 +237,13 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
       value: "backup_job",
       editable: false,
       forceSelection: true,
+      autoEl: {
+        tag: "div",
+        "data-qtip": gettext(
+          "Backup Job: verify snapshots from a single backup job. " +
+          "Namespace: randomly select from all backup jobs in a datastore namespace."
+        ),
+      },
       listeners: {
         change: function (combo, val) {
           var panel = combo.up("pbsD2DVerificationOptionsPanel");
@@ -338,6 +354,14 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
       forceSelection: true,
       allowBlank: false,
       value: "random_spot",
+      autoEl: {
+        tag: "div",
+        "data-qtip": gettext(
+          "Random Spot Check: sample a random set of files from each snapshot and " +
+          "verify their contents against the source agent. This provides statistical " +
+          "confidence in backup integrity without reading every file."
+        ),
+      },
     },
     {
       xtype: "proxmoxtextfield",
@@ -394,6 +418,15 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
 
   column1: [
     {
+      xtype: "component",
+      html:
+        '<span style="color:#555;font-size:11px;">' +
+        "Control how many files are checked per run and how they are selected. " +
+        "More samples yield higher statistical confidence. " +
+        'With 60+ samples and zero failures, confidence exceeds 95%.</span>',
+      margin: "0 0 8 0",
+    },
+    {
       xtype: "combo",
       fieldLabel: gettext("Sample Mode"),
       name: "sample_count_mode",
@@ -430,6 +463,13 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
       maxValue: 100000,
       value: 60,
       allowBlank: false,
+      autoEl: {
+        tag: "div",
+        "data-qtip": gettext(
+          "Number of files to verify per run. 60 samples with zero failures gives " +
+          "95% confidence that at least 95% of data is intact."
+        ),
+      },
     },
     {
       xtype: "numberfield",

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -304,12 +304,13 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
         },
         {
           xtype: 'displayfield',
-          cls: 'pmx-hint',
+          userCls: 'pmx-hint',
           value: gettext(
             "A backup job is randomly selected each run, weighted toward jobs " +
             "that have not been verified recently or have never been verified. " +
             "If a snapshot has no eligible files, the next candidate is tried."
           ),
+          width: '100%',
           padding: '5 0 0 0',
         },
         {

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -11,15 +11,15 @@ var verificationModes = Ext.create("Ext.data.Store", {
 
 var strategyDescriptions = {
   random:
-    '<i class="fa fa-shuffle" style="margin-right:4px;color:#888;"></i>' +
+    '<i class="fa fa-shuffle" style="margin-right:4px;opacity:0.6;"></i>' +
     '<b>Random</b> — Shuffle all eligible files and pick the first N. ' +
     "Provides statistically uniform coverage. Best for general-purpose verification.",
   systematic:
-    '<i class="fa fa-arrows-left-right" style="margin-right:4px;color:#888;"></i>' +
+    '<i class="fa fa-arrows-left-right" style="margin-right:4px;opacity:0.6;"></i>' +
     '<b>Systematic</b> — Sort files by path, then pick evenly-spaced entries. ' +
     "Ensures broad spatial coverage across the entire archive.",
   stratified:
-    '<i class="fa fa-layer-group" style="margin-right:4px;color:#888;"></i>' +
+    '<i class="fa fa-layer-group" style="margin-right:4px;opacity:0.6;"></i>' +
     '<b>Stratified</b> — Group files by top-level directory, then sample proportionally from each group. ' +
     "Ensures every directory tree is represented.",
 };
@@ -209,7 +209,7 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
     {
       xtype: "component",
       html:
-        '<span style="color:#555;font-size:11px;">' +
+        '<span class="pmx-hint" style="display:block;padding:4px 6px;font-size:11px;">' +
         "Configure which backup snapshots to verify and how often to run checks. " +
         "Each run samples files from a snapshot and validates their integrity." +
         '</span>',
@@ -420,7 +420,7 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
     {
       xtype: "component",
       html:
-        '<span style="color:#555;font-size:11px;">' +
+        '<span class="pmx-hint" style="display:block;padding:4px 6px;font-size:11px;">' +
         "Control how many files are checked per run and how they are selected. " +
         "More samples yield higher statistical confidence. " +
         'With 60+ samples and zero failures, confidence exceeds 95%.</span>',
@@ -732,7 +732,7 @@ Ext.define("PBS.D2DVerification.SpotCheckInputPanel", {
         {
           xtype: "component",
           html:
-            '<span style="color:#555;font-size:11px;">' +
+            '<span class="pmx-hint" style="display:block;padding:4px 6px;font-size:11px;">' +
             gettext("Filters restrict which files are eligible for spot checks. " +
               "A file must match at least one filter to be included. " +
               "Leave empty to sample from all files.") +

--- a/internal/server/web/views/custom/windows/verification.js
+++ b/internal/server/web/views/custom/windows/verification.js
@@ -303,6 +303,16 @@ Ext.define("PBS.D2DVerification.OptionsInputPanel", {
           margin: "5 0 0 0",
         },
         {
+          xtype: 'displayfield',
+          cls: 'pmx-hint',
+          value: gettext(
+            "A backup job is randomly selected each run, weighted toward jobs " +
+            "that have not been verified recently or have never been verified. " +
+            "If a snapshot has no eligible files, the next candidate is tried."
+          ),
+          padding: '5 0 0 0',
+        },
+        {
           xtype: "checkbox",
           name: "recursive",
           fieldLabel: gettext("Recursive"),


### PR DESCRIPTION
## Summary

Improvements to the verification system's UX, statistical presentation, and reliability.

### Dashboard & Aggregation
- Aggregate stats bar at top of verification panel (total runs, files verified, clean/failed runs, last 30 days, overall pass rate, 95% confidence)
- New `/api2/json/d2d/verification/aggregate` endpoint with `VerificationAggregate` type and `ComputeAggregate` function

### Pass/Fail Semantics
- `status_badge` field (`passed`/`failed`/`warning`) on every `FlatVerificationResult`
- "Last Result" column on verification jobs grid with pass/fail badges
- Per-run result badge in results window
- Summary line with PASS/FAIL verdict in result detail view

### Snapshot Labels
- `snapshot_human` field on `FlatVerificationResult` and `FlatRestore` — prepends namespace for context (e.g. `clients/acme: host/DP-D007/2025-03-22T12:50:02Z`)
- Verification jobs grid: "Target" column shows namespace path for namespace-mode jobs

### Operator Descriptions
- Panel header explains verification purpose
- Options tab, Spot Check Settings tab, File Filters, and Results window all have descriptive text using `pmx-hint` class (dark-mode compatible)
- Tooltips on Target Mode, Verification Mode, and Sample Count fields

### Default Sample Count
- Bumped from 10 to 60 — produces ≥95% confidence at 95% CI with zero failures

### Namespace Mode Fallback
- When `ErrNoFilesToVerify` is hit in namespace mode, the loop continues to the next backup job instead of failing
- Stale result records are marked `"skipped"`

### UI Fixes
- Replaced emojis with unicode symbols (✓ ✗ ⚠ ○) matching existing codebase
- Replaced hardcoded `#555`/`#888` colors with `pmx-hint` class and `opacity`/`inherit` for dark mode compatibility

## Test Plan
- [ ] Create verification job in backup_job mode — verify runs and shows results
- [ ] Create verification job in namespace mode — verify weighted random selection works
- [ ] Check aggregate stats bar updates correctly
- [ ] Verify snapshot labels include namespace prefix
- [ ] Verify "Target" column shows namespace for namespace-mode jobs
- [ ] Check descriptions appear correctly in both light and dark themes
- [ ] Confirm default sample count is 60 for new jobs