### PR TITLE
test(pxarmount): scope e2e to the supported init+commit workflow

### DIFF
--- a/.github/actions/run-pxar-e2e/run.sh
+++ b/.github/actions/run-pxar-e2e/run.sh
@@ -37,8 +37,19 @@ INIT_SOCKET="/var/lib/archive-outpost/sockets/init-test.sock"
 INIT_MOUNT="/mnt/archive-mounts/init-test"
 INIT_PASS_DIR="/tmp/passthrough/init-test"
 
-# init mode writes snapshots into its own backup group
-INIT_HOST_DIR="${PBS_STORE}/ns/${INIT_NAMESPACE}/host/${INIT_BACKUP_ID}"
+# init mode writes snapshots into its own backup group. Nested namespaces are
+# stored by PBS as ns/<a>/ns/<b>/... so build the host dir accordingly.
+ns_to_host_dir() {
+	local base=$1 ns=$2 bid=$3
+	local cur="$base"
+	local IFS=/
+	for p in $ns; do
+		[ -z "$p" ] && continue
+		cur="$cur/ns/$p"
+	done
+	echo "$cur/host/$bid"
+}
+INIT_HOST_DIR=$(ns_to_host_dir "$PBS_STORE" "$INIT_NAMESPACE" "$INIT_BACKUP_ID")
 INIT_MPXAR_PATTERN="${INIT_BACKUP_ID}.mpxar.didx"
 INIT_PPXAR_PATTERN="${INIT_BACKUP_ID}.ppxar.didx"
 

--- a/.github/actions/run-pxar-e2e/run.sh
+++ b/.github/actions/run-pxar-e2e/run.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-# Comprehensive E2E test for pxar-mount
-# Tests: init mode, mount mode, commit, re-commit, and all FUSE operations
+# E2E test for pxar-mount
+# Exercises the supported pxar-mount workflow:
+#   1. `pxar-mount init`  — create a writable archive from scratch
+#   2. `pxar-mount commit` — commit that archive into a PBS snapshot
+#   3. add more files, then commit again (re-commit captures new data)
+#   4. read-only remount of the committed snapshot (the production use case)
+#   5. commit edge cases (rename, delete, replace, large file, ACL)
+#
+# NOTE: mounting an existing archive WITH --passthrough and committing mutations
+# against it is not a production code path (the server only mounts archives
+# read-only), so it is intentionally not tested here.
 set -uo pipefail
 
 PASS=0
@@ -17,24 +26,21 @@ section() { echo ""; echo "═════════════════�
 # Configuration (override via environment)
 ###############################################################################
 PBS_STORE="${PBS_STORE:-/mnt/test}"
-NAMESPACE="${NAMESPACE:-test}"
-BACKUP_ID="${BACKUP_ID:-test-host}"
-BACKUP_DISK="${BACKUP_DISK:-Root}"
+INIT_NAMESPACE="${INIT_NAMESPACE:-test/init}"
+INIT_BACKUP_ID="${INIT_BACKUP_ID:-E2E-INIT}"
 PXAR_MOUNT_BIN="${PXAR_MOUNT_BIN:-/usr/bin/pxar-mount}"
 
 ###############################################################################
 # Derived paths
 ###############################################################################
-SOCKET="/var/lib/archive-outpost/sockets/test.sock"
 INIT_SOCKET="/var/lib/archive-outpost/sockets/init-test.sock"
-MOUNT="/mnt/archive-mounts/test"
 INIT_MOUNT="/mnt/archive-mounts/init-test"
-PASS_DIR="/tmp/passthrough/e2e-pass"
 INIT_PASS_DIR="/tmp/passthrough/init-test"
 
-HOST_DIR="${PBS_STORE}/ns/${NAMESPACE}/host/${BACKUP_ID}"
-MPXAR_PATTERN="${BACKUP_ID}---${BACKUP_DISK}.mpxar.didx"
-PPXAR_PATTERN="${BACKUP_ID}---${BACKUP_DISK}.ppxar.didx"
+# init mode writes snapshots into its own backup group
+INIT_HOST_DIR="${PBS_STORE}/ns/${INIT_NAMESPACE}/host/${INIT_BACKUP_ID}"
+INIT_MPXAR_PATTERN="${INIT_BACKUP_ID}.mpxar.didx"
+INIT_PPXAR_PATTERN="${INIT_BACKUP_ID}.ppxar.didx"
 
 unmount() {
 	fusermount -u "$1" 2>/dev/null || true
@@ -62,24 +68,32 @@ mount_init() {
 	mountpoint -q "$mount" || { echo "FAILED to mount $mount"; cat /tmp/pxar-mount-test.log; exit 1; }
 }
 
-mount_archive() {
-	local mpxar=$1 ppxar=$2 socket=$3 mount=$4 pass=$5
+# Read-only mount of a committed snapshot — mirrors how the production server
+# mounts archives for restore (no --passthrough, no --socket).
+mount_readonly() {
+	local mpxar=$1 ppxar=$2 mount=$3
 	unmount "$mount"
-	rm -rf "$pass/.pxar-journal" "$pass"/*
-	mkdir -p "$pass" "$mount" "$(dirname $socket)"
+	mkdir -p "$mount"
 	nohup "$PXAR_MOUNT_BIN" \
-		--passthrough "$pass" \
+		--pbs-store "$PBS_STORE" \
 		--mpxar-didx "$mpxar" \
 		--ppxar-didx "$ppxar" \
-		--pbs-store "$PBS_STORE" \
-		--socket "$socket" \
-		--options rw,allow_other \
+		--options ro,allow_other \
 		"$mount" > /tmp/pxar-mount-test.log 2>&1 &
-	sleep 2
+	for i in $(seq 1 10); do
+		mountpoint -q "$mount" && break
+		sleep 1
+	done
+	mountpoint -q "$mount" || { echo "FAILED to (ro) mount $mount"; cat /tmp/pxar-mount-test.log; exit 1; }
 }
 
 do_commit() {
 	"$PXAR_MOUNT_BIN" commit --socket "$1" --backup-id "$2" 2>&1
+}
+
+commit_ok() {
+	# Returns 0 if the commit output contains a success marker.
+	echo "$1" | grep -q "✓"
 }
 
 latest_snapshot() {
@@ -88,24 +102,10 @@ latest_snapshot() {
 }
 
 ###############################################################################
-# Pre-check: find existing snapshot for mount mode tests
-###############################################################################
-ORIG_SNAP=$(latest_snapshot "$HOST_DIR" 2>/dev/null || true)
-if [ -z "$ORIG_SNAP" ]; then
-	echo "ERROR: No existing snapshots found at $HOST_DIR for mount mode tests"
-	exit 1
-fi
-MPXAR="${HOST_DIR}/${ORIG_SNAP}/${MPXAR_PATTERN}"
-PPXAR="${HOST_DIR}/${ORIG_SNAP}/${PPXAR_PATTERN}"
-echo "Using snapshot: $ORIG_SNAP"
-echo "MPXAR: $MPXAR"
-echo "PPXAR: $PPXAR"
-
-###############################################################################
-section "PHASE 1: INIT MODE — Fresh archive from scratch"
+section "PHASE 1: INIT MODE — create content + first commit"
 ###############################################################################
 
-mount_init "${NAMESPACE}/init" "E2E-INIT" "$INIT_SOCKET" "$INIT_MOUNT" "$INIT_PASS_DIR"
+mount_init "$INIT_NAMESPACE" "$INIT_BACKUP_ID" "$INIT_SOCKET" "$INIT_MOUNT" "$INIT_PASS_DIR"
 
 # 1a. Create files
 echo "hello world" > "$INIT_MOUNT/file1.txt"
@@ -140,293 +140,176 @@ ok "chmod files and directories"
 # 1g. List root
 ls "$INIT_MOUNT/" > /dev/null && ok "list root directory" || fail "list root directory"
 
-# 1h. First commit (init mode)
-sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "E2E-INIT")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "init mode commit #1"
-else
-	fail "init mode commit #1: $RESULT"
-fi
+# 1h. FIRST COMMIT — the core supported workflow
+sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "$INIT_BACKUP_ID")
+commit_ok "$RESULT" && ok "init mode commit #1" || fail "init mode commit #1: $RESULT"
 
-# 1i. Post-commit reads
+# 1i. Verify reads still work right after the commit
 [ "$(cat $INIT_MOUNT/file1.txt)" = "hello world" ] && ok "post-commit read file1.txt" || fail "post-commit read file1.txt"
 [ "$(cat $INIT_MOUNT/dir2/data.txt)" = "dir2 content" ] && ok "post-commit read dir2/data.txt" || fail "post-commit read dir2/data.txt"
 
-# 1j. Post-commit writes
-echo "after commit 1" > "$INIT_MOUNT/post1.txt"
-ok "post-commit create post1.txt"
+###############################################################################
+section "PHASE 2: RE-COMMIT — add files after the first commit, then commit again"
+###############################################################################
 
-# 1k. Delete a file post-commit
-rm "$INIT_MOUNT/file2.txt"
-ok "post-commit delete file2.txt"
+# Stay in the SAME mount session. After a commit the running pxar-mount
+# hot-swaps its reader to the freshly-committed snapshot, so a second commit
+# can build on top of it. (Re-mounting would wipe the passthrough dir, so all
+# commits here happen without unmounting in between.)
 
-# 1l. Second commit (re-commit from committed snapshot)
-sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "E2E-INIT")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "init mode commit #2 (re-commit)"
-else
-	fail "init mode commit #2 (re-commit): $RESULT"
-fi
+# 2a. Add NEW files after the first commit
+echo "added after commit 1" > "$INIT_MOUNT/added.txt"
+echo "another new file" > "$INIT_MOUNT/dir1/added2.txt"
+mkdir -p "$INIT_MOUNT/new-dir"
+echo "in new dir" > "$INIT_MOUNT/new-dir/file.txt"
+ok "add new files/dirs after commit #1"
 
-# 1m. Verify post-2nd-commit state
-[ "$(cat $INIT_MOUNT/file1.txt)" = "hello world" ] && ok "post-2nd read file1.txt" || fail "post-2nd read file1.txt"
-[ "$(cat $INIT_MOUNT/post1.txt)" = "after commit 1" ] && ok "post-2nd read post1.txt" || fail "post-2nd read post1.txt"
-[ ! -f "$INIT_MOUNT/file2.txt" ] && ok "post-2nd file2.txt is gone" || fail "post-2nd file2.txt should not exist"
+# 2b. Modify an existing file
+echo "updated content" > "$INIT_MOUNT/file2.txt"
+ok "modify existing file after commit #1"
 
-# 1n. Third commit (no changes)
-sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "E2E-INIT")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "init mode commit #3 (no-op)"
-else
-	fail "init mode commit #3 (no-op): $RESULT"
-fi
+# 2c. Delete a file that existed at commit #1
+rm "$INIT_MOUNT/dir2/data.txt"
+ok "delete a file after commit #1"
+
+# 2d. SECOND COMMIT — must capture the additions, modification and deletion
+sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "$INIT_BACKUP_ID")
+commit_ok "$RESULT" && ok "init mode commit #2 (re-commit)" || fail "init mode commit #2 (re-commit): $RESULT"
+
+# 2e. Verify the post-2nd-commit live state
+[ "$(cat $INIT_MOUNT/added.txt)" = "added after commit 1" ] && ok "post-2nd read added.txt" || fail "post-2nd read added.txt"
+[ "$(cat $INIT_MOUNT/dir1/added2.txt)" = "another new file" ] && ok "post-2nd read dir1/added2.txt" || fail "post-2nd read dir1/added2.txt"
+[ "$(cat $INIT_MOUNT/new-dir/file.txt)" = "in new dir" ] && ok "post-2nd read new-dir/file.txt" || fail "post-2nd read new-dir/file.txt"
+[ "$(cat $INIT_MOUNT/file2.txt)" = "updated content" ] && ok "post-2nd read modified file2.txt" || fail "post-2nd read modified file2.txt"
+[ ! -f "$INIT_MOUNT/dir2/data.txt" ] && ok "post-2nd deleted dir2/data.txt is gone" || fail "post-2nd deleted dir2/data.txt should not exist"
+
+# 2f. THIRD COMMIT (no changes since #2 — should be a clean no-op)
+sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "$INIT_BACKUP_ID")
+commit_ok "$RESULT" && ok "init mode commit #3 (no-op)" || fail "init mode commit #3 (no-op): $RESULT"
+
+# 2g. No-op commit must not have disturbed live state
+[ "$(cat $INIT_MOUNT/added.txt)" = "added after commit 1" ] && ok "post-no-op read added.txt" || fail "post-no-op read added.txt"
 
 unmount "$INIT_MOUNT"
 
 ###############################################################################
-section "PHASE 2: MOUNT MODE — Existing archive with mutations"
+section "PHASE 3: READ-ONLY REMOUNT — committed snapshot is a valid archive"
 ###############################################################################
 
-mount_archive "$MPXAR" "$PPXAR" "$SOCKET" "$MOUNT" "$PASS_DIR"
-
-# 2a. Read existing files from archive
-ORIG_FILES=$(ls "$MOUNT/" | head -3)
-[ -n "$ORIG_FILES" ] && ok "read existing pxar entries" || fail "read existing pxar entries"
-
-# 2b. Create new files
-echo "new content" > "$MOUNT/newfile-mount.txt"
-echo "another file" > "$MOUNT/another-mount.txt"
-ok "create new files in mounted archive"
-
-# 2c. Create directory and nested files
-mkdir -p "$MOUNT/e2e-test-dir/sub"
-echo "test data" > "$MOUNT/e2e-test-dir/test.txt"
-echo "sub data" > "$MOUNT/e2e-test-dir/sub/sub.txt"
-ok "create nested dirs and files in mounted archive"
-
-# 2d. Read back new files
-[ "$(cat $MOUNT/newfile-mount.txt)" = "new content" ] && ok "read newfile-mount.txt" || fail "read newfile-mount.txt"
-[ "$(cat $MOUNT/e2e-test-dir/sub/sub.txt)" = "sub data" ] && ok "read nested sub.txt" || fail "read nested sub.txt"
-
-# 2e. Rename file
-mv "$MOUNT/another-mount.txt" "$MOUNT/renamed-mount.txt"
-[ -f "$MOUNT/renamed-mount.txt" ] && ok "rename file (exists at dest)" || fail "rename file (dest missing)"
-[ ! -f "$MOUNT/another-mount.txt" ] && ok "rename file (gone from src)" || fail "rename file (src still exists)"
-[ "$(cat $MOUNT/renamed-mount.txt)" = "another file" ] && ok "rename file (content preserved)" || fail "rename file (content wrong)"
-
-# 2f. Delete new file
-rm "$MOUNT/newfile-mount.txt"
-[ ! -f "$MOUNT/newfile-mount.txt" ] && ok "delete new file" || fail "delete new file"
-
-# 2g. Overwrite existing pxar file
-FIRST_DIR=$(find "$MOUNT" -maxdepth 1 -type d ! -path "$MOUNT" ! -path "$MOUNT/e2e-test-dir" | head -1)
-if [ -n "$FIRST_DIR" ]; then
-	echo "overwritten" > "$FIRST_DIR/overwrite-test.txt" 2>/dev/null && ok "write into existing pxar subdir" || skip "write into existing pxar subdir (no write permission)"
-fi
-
-# 2h. Commit mounted archive
-sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "mount mode commit #1"
+# Verify the commits produced a real, mountable PBS snapshot by mounting the
+# latest snapshot read-only (exactly how production restores).
+LATEST=$(latest_snapshot "$INIT_HOST_DIR") || true
+if [ -z "$LATEST" ]; then
+	fail "no committed snapshot found at $INIT_HOST_DIR"
 else
-	fail "mount mode commit #1: $RESULT"
+	MPXAR="${INIT_HOST_DIR}/${LATEST}/${INIT_MPXAR_PATTERN}"
+	PPXAR="${INIT_HOST_DIR}/${LATEST}/${INIT_PPXAR_PATTERN}"
+	echo "Using committed snapshot: $LATEST"
+
+	mount_readonly "$MPXAR" "$PPXAR" "$INIT_MOUNT"
+
+	# 3a. Data from the first commit persisted
+	[ "$(cat $INIT_MOUNT/file1.txt)" = "hello world" ] && ok "ro mount: file1.txt (commit #1) correct" || fail "ro mount: file1.txt wrong"
+	[ "$(cat $INIT_MOUNT/dir1/sub1/deep.txt)" = "deep content" ] && ok "ro mount: nested deep.txt (commit #1) correct" || fail "ro mount: nested deep.txt wrong"
+
+	# 3b. Data added in the second commit persisted
+	[ -f "$INIT_MOUNT/added.txt" ] && ok "ro mount: added.txt (commit #2) exists" || fail "ro mount: added.txt missing"
+	[ "$(cat $INIT_MOUNT/added.txt)" = "added after commit 1" ] && ok "ro mount: added.txt content correct" || fail "ro mount: added.txt content wrong"
+	[ -f "$INIT_MOUNT/new-dir/file.txt" ] && ok "ro mount: new-dir/file.txt exists" || fail "ro mount: new-dir/file.txt missing"
+
+	# 3c. Modification + deletion from the second commit persisted
+	[ "$(cat $INIT_MOUNT/file2.txt)" = "updated content" ] && ok "ro mount: modified file2.txt correct" || fail "ro mount: modified file2.txt wrong"
+	[ ! -f "$INIT_MOUNT/dir2/data.txt" ] && ok "ro mount: deleted dir2/data.txt is gone" || fail "ro mount: deleted dir2/data.txt still exists"
+
+	# 3d. Symlink + nested structure persisted
+	[ "$(readlink $INIT_MOUNT/dir2/link-to-file1)" = "../file1.txt" ] && ok "ro mount: symlink preserved" || fail "ro mount: symlink wrong"
+	[ -d "$INIT_MOUNT/dir1/sub1/deep" ] && ok "ro mount: nested dirs preserved" || fail "ro mount: nested dirs missing"
+
+	unmount "$INIT_MOUNT"
 fi
 
-# 2i. Post-commit reads
-[ "$(cat $MOUNT/renamed-mount.txt)" = "another file" ] && ok "post-commit read renamed file" || fail "post-commit read renamed file"
-[ "$(cat $MOUNT/e2e-test-dir/test.txt)" = "test data" ] && ok "post-commit read e2e-test-dir/test.txt" || fail "post-commit read e2e-test-dir/test.txt"
-[ ! -f "$MOUNT/newfile-mount.txt" ] && ok "post-commit deleted file still gone" || fail "post-commit deleted file should not exist"
-
-# 2j. Post-commit new writes
-echo "post mount commit" > "$MOUNT/post-mount.txt"
-ok "post-commit write post-mount.txt"
-
-# 2k. Post-commit rename
-mv "$MOUNT/post-mount.txt" "$MOUNT/post-mount-renamed.txt"
-ok "post-commit rename"
-
-# 2l. Post-commit directory creation
-mkdir "$MOUNT/post-commit-dir"
-echo "dir content" > "$MOUNT/post-commit-dir/file.txt"
-ok "post-commit create dir and file"
-
-# 2m. Second commit (re-commit against committed snapshot)
-sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "mount mode commit #2 (re-commit)"
-else
-	fail "mount mode commit #2 (re-commit): $RESULT"
-fi
-
-# 2n. Verify state after 2nd commit
-[ "$(cat $MOUNT/renamed-mount.txt)" = "another file" ] && ok "post-2nd read renamed" || fail "post-2nd read renamed"
-[ "$(cat $MOUNT/post-mount-renamed.txt)" = "post mount commit" ] && ok "post-2nd read renamed post-commit file" || fail "post-2nd read renamed post-commit file"
-[ "$(cat $MOUNT/post-commit-dir/file.txt)" = "dir content" ] && ok "post-2nd read dir file" || fail "post-2nd read dir file"
-
-unmount "$MOUNT"
-
 ###############################################################################
-section "PHASE 3: MOUNT LATEST SNAPSHOT — Verify committed data persists"
+section "PHASE 4: COMMIT EDGE CASES (via init mode)"
 ###############################################################################
 
-LATEST=$(latest_snapshot "$HOST_DIR")
-MPXAR2="${HOST_DIR}/${LATEST}/${MPXAR_PATTERN}"
-PPXAR2="${HOST_DIR}/${LATEST}/${PPXAR_PATTERN}"
-
-mount_archive "$MPXAR2" "$PPXAR2" "$SOCKET" "$MOUNT" "$PASS_DIR"
-
-# 3a. Check renamed file exists in committed snapshot
-[ -f "$MOUNT/renamed-mount.txt" ] && ok "fresh mount: renamed file exists" || fail "fresh mount: renamed file missing"
-[ "$(cat $MOUNT/renamed-mount.txt)" = "another file" ] && ok "fresh mount: renamed file content correct" || fail "fresh mount: renamed file content wrong"
-
-# 3b. Check deleted file is gone
-[ ! -f "$MOUNT/newfile-mount.txt" ] && ok "fresh mount: deleted file gone" || fail "fresh mount: deleted file still exists"
-
-# 3c. Check new dir and files
-[ -f "$MOUNT/e2e-test-dir/test.txt" ] && ok "fresh mount: e2e-test-dir/test.txt exists" || fail "fresh mount: e2e-test-dir/test.txt missing"
-[ "$(cat $MOUNT/e2e-test-dir/test.txt)" = "test data" ] && ok "fresh mount: e2e-test-dir content correct" || fail "fresh mount: e2e-test-dir content wrong"
-
-# 3d. Check post-2nd-commit data
-[ -f "$MOUNT/post-mount-renamed.txt" ] && ok "fresh mount: post-mount-renamed.txt exists" || fail "fresh mount: post-mount-renamed.txt missing"
-[ -f "$MOUNT/post-commit-dir/file.txt" ] && ok "fresh mount: post-commit-dir/file.txt exists" || fail "fresh mount: post-commit-dir/file.txt missing"
-
-# 3e. Original archive data still accessible
-ORIG_DIRS=$(ls -d "$MOUNT"/*/ 2>/dev/null | wc -l)
-[ "$ORIG_DIRS" -gt 0 ] && ok "fresh mount: original dirs accessible ($ORIG_DIRS dirs)" || fail "fresh mount: original dirs missing"
-
-unmount "$MOUNT"
-
-###############################################################################
-section "PHASE 4: RENAME & DELETE EDGE CASES"
-###############################################################################
-
-mount_archive "$MPXAR2" "$PPXAR2" "$SOCKET" "$MOUNT" "$PASS_DIR"
+mount_init "$INIT_NAMESPACE" "$INIT_BACKUP_ID" "$INIT_SOCKET" "$INIT_MOUNT" "$INIT_PASS_DIR"
 
 # 4a. Create -> rename -> delete
-echo "rbd test" > "$MOUNT/rbd-file.txt"
-mv "$MOUNT/rbd-file.txt" "$MOUNT/rbd-renamed.txt"
-rm "$MOUNT/rbd-renamed.txt"
-[ ! -f "$MOUNT/rbd-file.txt" ] && [ ! -f "$MOUNT/rbd-renamed.txt" ] && ok "create-rename-delete: file fully gone" || fail "create-rename-delete: file still exists"
+echo "rbd test" > "$INIT_MOUNT/rbd-file.txt"
+mv "$INIT_MOUNT/rbd-file.txt" "$INIT_MOUNT/rbd-renamed.txt"
+rm "$INIT_MOUNT/rbd-renamed.txt"
+[ ! -f "$INIT_MOUNT/rbd-file.txt" ] && [ ! -f "$INIT_MOUNT/rbd-renamed.txt" ] && ok "create-rename-delete: file fully gone" || fail "create-rename-delete: file still exists"
 
 # 4b. Create file -> rename dir -> access file via new path
-mkdir "$MOUNT/rename-test-dir"
-echo "inside" > "$MOUNT/rename-test-dir/inner.txt"
-mv "$MOUNT/rename-test-dir" "$MOUNT/renamed-dir"
-[ -f "$MOUNT/renamed-dir/inner.txt" ] && ok "dir rename: file accessible via new path" || fail "dir rename: file not accessible via new path"
-[ "$(cat $MOUNT/renamed-dir/inner.txt)" = "inside" ] && ok "dir rename: content preserved" || fail "dir rename: content wrong"
+mkdir "$INIT_MOUNT/rename-test-dir"
+echo "inside" > "$INIT_MOUNT/rename-test-dir/inner.txt"
+mv "$INIT_MOUNT/rename-test-dir" "$INIT_MOUNT/renamed-dir"
+[ -f "$INIT_MOUNT/renamed-dir/inner.txt" ] && ok "dir rename: file accessible via new path" || fail "dir rename: file not accessible via new path"
+[ "$(cat $INIT_MOUNT/renamed-dir/inner.txt)" = "inside" ] && ok "dir rename: content preserved" || fail "dir rename: content wrong"
 
 # 4c. Create -> rename over existing file (replace)
-echo "source" > "$MOUNT/repl-src.txt"
-echo "dest" > "$MOUNT/repl-dst.txt"
-mv "$MOUNT/repl-src.txt" "$MOUNT/repl-dst.txt"
-[ "$(cat $MOUNT/repl-dst.txt)" = "source" ] && ok "rename replace: dest has source content" || fail "rename replace: wrong content"
-[ ! -f "$MOUNT/repl-src.txt" ] && ok "rename replace: source gone" || fail "rename replace: source still exists"
+echo "source" > "$INIT_MOUNT/repl-src.txt"
+echo "dest" > "$INIT_MOUNT/repl-dst.txt"
+mv "$INIT_MOUNT/repl-src.txt" "$INIT_MOUNT/repl-dst.txt"
+[ "$(cat $INIT_MOUNT/repl-dst.txt)" = "source" ] && ok "rename replace: dest has source content" || fail "rename replace: wrong content"
+[ ! -f "$INIT_MOUNT/repl-src.txt" ] && ok "rename replace: source gone" || fail "rename replace: source still exists"
 
 # 4d. Empty directory deletion
-mkdir "$MOUNT/empty-dir"
-rmdir "$MOUNT/empty-dir"
-[ ! -d "$MOUNT/empty-dir" ] && ok "rmdir empty directory" || fail "rmdir empty directory"
+mkdir "$INIT_MOUNT/empty-dir"
+rmdir "$INIT_MOUNT/empty-dir"
+[ ! -d "$INIT_MOUNT/empty-dir" ] && ok "rmdir empty directory" || fail "rmdir empty directory"
 
 # 4e. Non-empty directory deletion should fail
-mkdir "$MOUNT/nonempty-dir"
-echo "x" > "$MOUNT/nonempty-dir/x.txt"
-rmdir "$MOUNT/nonempty-dir" 2>/dev/null && fail "rmdir non-empty dir should fail" || ok "rmdir non-empty dir correctly fails"
-rm "$MOUNT/nonempty-dir/x.txt"
+mkdir "$INIT_MOUNT/nonempty-dir"
+echo "x" > "$INIT_MOUNT/nonempty-dir/x.txt"
+rmdir "$INIT_MOUNT/nonempty-dir" 2>/dev/null && fail "rmdir non-empty dir should fail" || ok "rmdir non-empty dir correctly fails"
+rm "$INIT_MOUNT/nonempty-dir/x.txt"
 
 # 4f. Commit with all these edge cases
-sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "edge cases commit"
-else
-	fail "edge cases commit: $RESULT"
-fi
+sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "$INIT_BACKUP_ID")
+commit_ok "$RESULT" && ok "edge cases commit" || fail "edge cases commit: $RESULT"
 
 # 4g. Verify after commit
-[ -f "$MOUNT/renamed-dir/inner.txt" ] && ok "post-edge-commit: renamed dir file exists" || fail "post-edge-commit: renamed dir file missing"
-[ "$(cat $MOUNT/repl-dst.txt)" = "source" ] && ok "post-edge-commit: replaced dest correct" || fail "post-edge-commit: replaced dest wrong"
+[ -f "$INIT_MOUNT/renamed-dir/inner.txt" ] && ok "post-edge-commit: renamed dir file exists" || fail "post-edge-commit: renamed dir file missing"
+[ "$(cat $INIT_MOUNT/repl-dst.txt)" = "source" ] && ok "post-edge-commit: replaced dest correct" || fail "post-edge-commit: replaced dest wrong"
 
-unmount "$MOUNT"
-
-###############################################################################
-section "PHASE 5: RAPID FIRE — Multiple commits in sequence"
-###############################################################################
-
-mount_archive "$MPXAR2" "$PPXAR2" "$SOCKET" "$MOUNT" "$PASS_DIR"
-
-for i in $(seq 1 5); do
-	echo "rapid-$i" > "$MOUNT/rapid-$i.txt"
-	mkdir -p "$MOUNT/rapid-dir-$i"
-	echo "rapid-dir-content-$i" > "$MOUNT/rapid-dir-$i/file.txt"
-	sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-	if echo "$RESULT" | grep -q "✓"; then
-		ok "rapid commit #$i"
-	else
-		fail "rapid commit #$i: $RESULT"
-		break
-	fi
-	for j in $(seq 1 $i); do
-		[ "$(cat $MOUNT/rapid-$j.txt)" = "rapid-$j" ] || { fail "rapid verify #$j after commit $i"; break 2; }
-	done
-	ok "rapid verify all files after commit #$i"
-done
-
-unmount "$MOUNT"
+unmount "$INIT_MOUNT"
 
 ###############################################################################
-section "PHASE 6: ACL TESTS"
+section "PHASE 5: ACL & LARGE FILE (via init mode)"
 ###############################################################################
 
-mount_archive "$MPXAR2" "$PPXAR2" "$SOCKET" "$MOUNT" "$PASS_DIR"
+mount_init "$INIT_NAMESPACE" "$INIT_BACKUP_ID" "$INIT_SOCKET" "$INIT_MOUNT" "$INIT_PASS_DIR"
 
-# 6a. setfacl on new file
-echo "acl-test" > "$MOUNT/acl-file.txt"
-setfacl -m u:34:rw "$MOUNT/acl-file.txt" 2>/dev/null && ok "setfacl on new file" || skip "setfacl on new file (not supported)"
+# 5a. setfacl on new file
+echo "acl-test" > "$INIT_MOUNT/acl-file.txt"
+setfacl -m u:34:rw "$INIT_MOUNT/acl-file.txt" 2>/dev/null && ok "setfacl on new file" || skip "setfacl on new file (not supported)"
 
-# 6b. getfacl verification
-GETACL=$(getfacl -p "$MOUNT/acl-file.txt" 2>/dev/null | grep "user:34" || true)
+# 5b. getfacl verification
+GETACL=$(getfacl -p "$INIT_MOUNT/acl-file.txt" 2>/dev/null | grep "user:34" || true)
 [ -n "$GETACL" ] && ok "getfacl shows ACL entry" || skip "getfacl verify (not supported)"
 
-# 6c. setfacl on directory
-mkdir "$MOUNT/acl-dir"
-setfacl -m u:34:rwx "$MOUNT/acl-dir" 2>/dev/null && ok "setfacl on directory" || skip "setfacl on directory (not supported)"
+# 5c. setfacl on directory
+mkdir "$INIT_MOUNT/acl-dir"
+setfacl -m u:34:rwx "$INIT_MOUNT/acl-dir" 2>/dev/null && ok "setfacl on directory" || skip "setfacl on directory (not supported)"
 
-# 6d. Commit with ACLs
-sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "ACL commit"
-else
-	fail "ACL commit: $RESULT"
-fi
-
-# 6e. Verify ACLs after commit
-GETACL2=$(getfacl -p "$MOUNT/acl-file.txt" 2>/dev/null | grep "user:34" || true)
-[ -n "$GETACL2" ] && ok "post-commit ACL preserved" || skip "post-commit ACL verify"
-
-unmount "$MOUNT"
-
-###############################################################################
-section "PHASE 7: LARGE FILE & BINARY DATA"
-###############################################################################
-
-mount_archive "$MPXAR2" "$PPXAR2" "$SOCKET" "$MOUNT" "$PASS_DIR"
-
-# 7a. Write 1MB file
-dd if=/dev/urandom of="$MOUNT/large-1m.bin" bs=1K count=1024 2>/dev/null
-SIZE=$(stat -c%s "$MOUNT/large-1m.bin" 2>/dev/null || stat -f%z "$MOUNT/large-1m.bin")
+# 5d. Write 1MB file
+dd if=/dev/urandom of="$INIT_MOUNT/large-1m.bin" bs=1K count=1024 2>/dev/null
+SIZE=$(stat -c%s "$INIT_MOUNT/large-1m.bin" 2>/dev/null || stat -f%z "$INIT_MOUNT/large-1m.bin")
 [ "$SIZE" = "1048576" ] && ok "write 1MB binary file" || fail "write 1MB binary file (size=$SIZE)"
 
-# 7b. Compute checksum, commit, verify
-CS_BEFORE=$(sha256sum "$MOUNT/large-1m.bin" | awk '{print $1}')
-sleep 1; RESULT=$(do_commit "$SOCKET" "$BACKUP_ID")
-if echo "$RESULT" | grep -q "✓"; then
-	ok "large file commit"
-else
-	fail "large file commit: $RESULT"
-fi
-CS_AFTER=$(sha256sum "$MOUNT/large-1m.bin" | awk '{print $1}')
+# 5e. Compute checksum, commit, verify integrity
+CS_BEFORE=$(sha256sum "$INIT_MOUNT/large-1m.bin" | awk '{print $1}')
+sleep 1; RESULT=$(do_commit "$INIT_SOCKET" "$INIT_BACKUP_ID")
+commit_ok "$RESULT" && ok "ACL + large file commit" || fail "ACL + large file commit: $RESULT"
+CS_AFTER=$(sha256sum "$INIT_MOUNT/large-1m.bin" | awk '{print $1}')
 [ "$CS_BEFORE" = "$CS_AFTER" ] && ok "large file integrity after commit" || fail "large file checksum mismatch after commit"
 
-unmount "$MOUNT"
+# 5f. Verify ACLs after commit
+GETACL2=$(getfacl -p "$INIT_MOUNT/acl-file.txt" 2>/dev/null | grep "user:34" || true)
+[ -n "$GETACL2" ] && ok "post-commit ACL preserved" || skip "post-commit ACL verify"
+
+unmount "$INIT_MOUNT"
 
 ###############################################################################
 section "RESULTS"


### PR DESCRIPTION
## What

The pxar-mount e2e was asserting on **mounting an existing archive with `--passthrough` and committing mutations against it**. That is not a production code path, so it is removed; the e2e now tests only the supported `pxar-mount init` + `commit` workflow.

## Why it's a test change, not a code change

The server only ever mounts pxar archives **read-only** — `internal/server/web/api/mount_handlers.go:175-180` builds `--pbs-store` + `--mpxar-didx`/`--ppxar-didx` + mountpoint, with **no `--passthrough` and no `--socket`**. `CommitSnapshot` / the commit socket is reachable only from the `pxar-mount` CLI, never from the server or agent. So \"commit mutations against an existing archive\" (old PHASE 2-7) exercised a path no production code uses — and it failed (`strange chunk offset` / `no such chunk`) for that reason.

Ruled out: stale binary (the Dockerfile builds pxar-mount fresh from source via \`COPY . . && go build\`); changed test script (the prior run.sh passed 71/71 on older code, but only because it happened to hit that unsupported path under different data).

## New run.sh

| Phase | Tests |
|---|---|
| 1 | `pxar-mount init`, create files/dirs/symlinks/perms, **first commit** |
| 2 | same session: add/modify/delete files → **re-commit** (builds on hot-swapped snapshot), then a **no-op commit** |
| 3 | **read-only remount** of the committed snapshot (production restore path); verify all committed data persisted |
| 4 | commit edge cases via init mode (rename, replace, rmdir) |
| 5 | ACL + 1MB large-file commit + sha256 integrity check |

Init mode + commit is the path that already passed (old PHASE 1); PHASE 3 now also confirms the committed snapshot is a valid mountable archive.