### PR TITLE
feat(jobs): show queued tasks while jobs wait for engine slots

### DIFF
--- a/internal/proxmox/tasklog/active.go
+++ b/internal/proxmox/tasklog/active.go
@@ -27,6 +27,16 @@ var (
 
 const lockTimeout = 15 * time.Second
 
+// UseTaskDir redirects all task-log paths to dir and returns a restore func
+// for tests outside this package (the path vars are package-private).
+func UseTaskDir(dir string) func() {
+	origTaskDir, origActive, origArchive, origLock := taskDir, activeTasks, archivePath, lockPath
+	taskDir, activeTasks, archivePath, lockPath = dir, filepath.Join(dir, "active"), filepath.Join(dir, "archive"), filepath.Join(dir, ".active.lock")
+	return func() {
+		taskDir, activeTasks, archivePath, lockPath = origTaskDir, origActive, origArchive, origLock
+	}
+}
+
 // taskListLock is PBS's TaskListLockGuard: an flock on tasks/.active.lock
 // held for the duration of a task-list read or update.
 type taskListLock struct{ f *os.File }

--- a/internal/proxmox/tasklog/queued_reuse_test.go
+++ b/internal/proxmox/tasklog/queued_reuse_test.go
@@ -2,7 +2,10 @@
 
 package tasklog
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 // NewQueuedTask must hand back the live task for the same worker so retries
 // keep one UPID and log, and mint a fresh task only after Close.
@@ -39,6 +42,29 @@ func TestNewQueuedTaskReusesLiveTask(t *testing.T) {
 	}
 	if got := QueuedState(first.UPID()); got != "" {
 		t.Fatalf("state after close = %q, want cleared", got)
+	}
+	fresh.Close()
+}
+
+func TestNewQueuedTaskFreshAfterCancelClose(t *testing.T) {
+	setupTaskDirs(t)
+
+	minted, err := NewQueuedTask("backup", "job-9", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upid := minted.UPID()
+	minted.CloseErr(errors.New("operation canceled"))
+
+	fresh, err := NewQueuedTask("backup", "job-9", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh == minted {
+		t.Fatal("canceled-closed task reused")
+	}
+	if fresh.UPID() == upid {
+		t.Fatalf("fresh task kept canceled UPID %q", upid)
 	}
 	fresh.Close()
 }

--- a/internal/server/backup/queue.go
+++ b/internal/server/backup/queue.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/proxmox"
+	"github.com/pbs-plus/pbs-plus/internal/proxmox/tasklog"
+	"github.com/pbs-plus/pbs-plus/internal/server/application"
+	"github.com/pbs-plus/pbs-plus/internal/server/coredb"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs/jobdb"
+)
+
+// PrepareQueue mints the queued task at submit time so a slot-waiting job is
+// visible (log, history, stoppable); the workflow's NewQueuedTask attaches by key.
+func PrepareQueue(app *application.Runtime, job coredb.Backup, web bool) error {
+	workerID, err := backupWorkerID(job)
+	if err != nil {
+		return err
+	}
+	queued, err := tasklog.NewQueuedTask("backup", workerID, web)
+	if err != nil {
+		return err
+	}
+	queued.OnAbort(func() { _ = CancelQueued(app, job) })
+	return updateBackupStatus(false, 0, job, proxmox.Task{UPID: queued.UPID()}, queued.Task.StartTime, 0, app)
+}
+
+// CancelQueued stops a queued job: pre-claim it closes the task as canceled
+// (JobStatusCanceled, retry counter untouched); claimed ones finalize normally.
+func CancelQueued(app *application.Runtime, job coredb.Backup) error {
+	ctx := context.Background()
+	exec, err := app.Engine.ActiveExecution(ctx, jobs.WorkflowBackup, job.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	exec, err = app.Engine.Cancel(ctx, exec.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if exec.State != jobdb.StateCanceled {
+		return nil
+	}
+	workerID, err := backupWorkerID(job)
+	if err != nil {
+		return err
+	}
+	queued, err := tasklog.NewQueuedTask("backup", workerID, false)
+	if err != nil {
+		return err
+	}
+	queued.CloseErr(jobs.ErrCanceled)
+	return updateBackupStatus(false, 0, job, proxmox.Task{UPID: queued.UPID()}, queued.Task.StartTime, time.Now().Unix(), app)
+}

--- a/internal/server/backup/queue_test.go
+++ b/internal/server/backup/queue_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package backup
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/proxmox/tasklog"
+	"github.com/pbs-plus/pbs-plus/internal/server/application"
+	"github.com/pbs-plus/pbs-plus/internal/server/coredb"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs/jobdb"
+)
+
+// A slot-waiting backup (engine never started, execution pending) is visible
+// as queued via PrepareQueue and cancels to JobStatusCanceled without
+// bumping the retry counter.
+func TestPrepareAndCancelQueuedSlotWait(t *testing.T) {
+	restoreTask := tasklog.UseTaskDir(t.TempDir())
+	defer restoreTask()
+
+	ctx := context.Background()
+	cdb, err := coredb.Initialize(ctx, filepath.Join(t.TempDir(), "core.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cdb.Close() })
+
+	engineDB, err := jobdb.Open(filepath.Join(t.TempDir(), "jobs.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = engineDB.Close() })
+
+	engine, err := jobs.NewEngine(engineDB, jobs.EngineConfig{Owner: "test", MaxConcurrent: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Register(jobs.WorkflowBackup, func(*jobs.WorkflowContext) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	job := coredb.Backup{ID: "queue-test-1", Store: "test-store", Target: coredb.Target{Name: "test-host", Path: "/data", Type: "s3"}}
+	if err := cdb.CreateBackup(nil, job); err != nil {
+		t.Fatal(err)
+	}
+	app := &application.Runtime{Ctx: ctx, CoreDB: cdb, Engine: engine}
+
+	request, err := jobs.NewWorkflowSubmit(jobs.WorkflowBackup, job.ID, "manual", "", jobs.BackupInput{}, []string{"backup:" + job.ID}, 2, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := engine.Submit(ctx, request); err != nil || !created {
+		t.Fatalf("submit: created=%v err=%v", created, err)
+	}
+
+	if err := PrepareQueue(app, job, true); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := cdb.GetBackup(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.History.LastRunUpid == "" {
+		t.Fatal("history upid not set at mint")
+	}
+
+	if err := CancelQueued(app, job); err != nil {
+		t.Fatal(err)
+	}
+	stored, err = cdb.GetBackup(job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.History.LastRunStatus != coredb.JobStatusCanceled {
+		t.Fatalf("status = %q, want canceled", stored.History.LastRunStatus)
+	}
+	if stored.History.RetryCount != 0 {
+		t.Fatalf("retry count = %d, want 0", stored.History.RetryCount)
+	}
+	taskFound, err := tasklog.GetTaskByUPID(stored.History.LastRunUpid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if taskFound.ExitStatus != "operation canceled" {
+		t.Fatalf("task exit = %q, want operation canceled", taskFound.ExitStatus)
+	}
+
+	if err := CancelQueued(app, job); err != nil {
+		t.Fatalf("second cancel: %v", err)
+	}
+}

--- a/internal/server/mtf/queue.go
+++ b/internal/server/mtf/queue.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+package mtf
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/proxmox/tasklog"
+	"github.com/pbs-plus/pbs-plus/internal/server/application"
+	"github.com/pbs-plus/pbs-plus/internal/server/coredb"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs/jobdb"
+	"github.com/pbs-plus/pbs-plus/internal/server/mtf/mtfdb"
+)
+
+// PrepareQueue mints the queued task at submit time so a slot-waiting job is
+// visible (log, history, stoppable); the workflow's NewQueuedTask attaches by key.
+func PrepareQueue(app *application.Runtime, jobID string, web bool) error {
+	ctx := app.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	job, err := app.MtfDB.GetMtfJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	queued, err := tasklog.NewQueuedTask(mtfWorkerType, tasklog.FormatWorkerID(job.Datastore, "mtf-", job.ID), web)
+	if err != nil {
+		return err
+	}
+	queued.OnAbort(func() { _ = CancelQueued(app, jobID) })
+	h := mtfdb.JobHistory{
+		LastRunUpid:      queued.UPID(),
+		LastRunStatus:    coredb.JobStatusUnknown,
+		LastRunStarttime: queued.Task.StartTime,
+	}
+	return app.MtfDB.UpdateMtfJobHistory(ctx, job.ID, h, "")
+}
+
+// CancelQueued stops a queued job: pre-claim it closes the task as canceled
+// (JobStatusCanceled, retry counter untouched); claimed ones finalize normally.
+func CancelQueued(app *application.Runtime, jobID string) error {
+	ctx := app.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	exec, err := app.Engine.ActiveExecution(ctx, jobs.WorkflowMtfMigration, jobID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	exec, err = app.Engine.Cancel(ctx, exec.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if exec.State != jobdb.StateCanceled {
+		return nil
+	}
+	job, err := app.MtfDB.GetMtfJob(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	queued, err := tasklog.NewQueuedTask(mtfWorkerType, tasklog.FormatWorkerID(job.Datastore, "mtf-", job.ID), false)
+	if err != nil {
+		return err
+	}
+	queued.CloseErr(jobs.ErrCanceled)
+	h := mtfdb.JobHistory{
+		LastRunUpid:      queued.UPID(),
+		LastRunStatus:    coredb.JobStatusCanceled,
+		LastRunStarttime: queued.Task.StartTime,
+		LastRunEndtime:   time.Now().Unix(),
+	}
+	return app.MtfDB.UpdateMtfJobHistory(ctx, job.ID, h, "")
+}

--- a/internal/server/restore/queue.go
+++ b/internal/server/restore/queue.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package restore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/proxmox"
+	"github.com/pbs-plus/pbs-plus/internal/proxmox/tasklog"
+	"github.com/pbs-plus/pbs-plus/internal/server/application"
+	"github.com/pbs-plus/pbs-plus/internal/server/coredb"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs/jobdb"
+)
+
+// PrepareQueue mints the queued task at submit time so a slot-waiting job is
+// visible (log, history, stoppable); the workflow's NewQueuedTask attaches by key.
+func PrepareQueue(app *application.Runtime, job coredb.Restore, web bool) error {
+	workerID := tasklog.FormatWorkerID(job.Store, "host-", job.DestTarget.GetHostname())
+	queued, err := tasklog.NewQueuedTask("reader", workerID, web)
+	if err != nil {
+		return err
+	}
+	queued.OnAbort(func() { _ = CancelQueued(app, job) })
+	return updateRestoreStatus(false, 0, job, proxmox.Task{UPID: queued.UPID()}, app)
+}
+
+// CancelQueued stops a queued job: pre-claim it closes the task as canceled
+// (JobStatusCanceled, retry counter untouched); claimed ones finalize normally.
+func CancelQueued(app *application.Runtime, job coredb.Restore) error {
+	ctx := context.Background()
+	exec, err := app.Engine.ActiveExecution(ctx, jobs.WorkflowRestore, job.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	exec, err = app.Engine.Cancel(ctx, exec.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if exec.State != jobdb.StateCanceled {
+		return nil
+	}
+	workerID := tasklog.FormatWorkerID(job.Store, "host-", job.DestTarget.GetHostname())
+	queued, err := tasklog.NewQueuedTask("reader", workerID, false)
+	if err != nil {
+		return err
+	}
+	queued.CloseErr(jobs.ErrCanceled)
+	task := proxmox.Task{UPID: queued.UPID(), StartTime: queued.Task.StartTime, EndTime: time.Now().Unix()}
+	return updateRestoreStatus(false, 0, job, task, app)
+}

--- a/internal/server/verification/queue.go
+++ b/internal/server/verification/queue.go
@@ -1,0 +1,76 @@
+//go:build linux
+
+package verification
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/pbs-plus/pbs-plus/internal/proxmox"
+	"github.com/pbs-plus/pbs-plus/internal/proxmox/tasklog"
+	"github.com/pbs-plus/pbs-plus/internal/server/application"
+	"github.com/pbs-plus/pbs-plus/internal/server/coredb"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs"
+	"github.com/pbs-plus/pbs-plus/internal/server/jobs/jobdb"
+)
+
+func queuedWorkerID(job coredb.VerificationJob) string {
+	return proxmox.EncodeToHexEscapes(job.ID)
+}
+
+// PrepareQueue mints the queued task at submit time so a slot-waiting job is
+// visible (log, history, stoppable); the workflow's NewQueuedTask attaches by key.
+func PrepareQueue(app *application.Runtime, job coredb.VerificationJob, web bool) error {
+	queued, err := tasklog.NewQueuedTask("verification", queuedWorkerID(job), web)
+	if err != nil {
+		return err
+	}
+	queued.OnAbort(func() { _ = CancelQueued(app, job) })
+	current, err := app.CoreDB.GetVerificationJob(job.ID)
+	if err != nil {
+		return err
+	}
+	current.History.LastRunUpid = queued.UPID()
+	current.History.LastRunStarttime = queued.Task.StartTime
+	current.History.LastRunState = ""
+	return app.CoreDB.UpdateVerificationJob(nil, current)
+}
+
+// CancelQueued stops a queued job: pre-claim it closes the task as canceled
+// (JobStatusCanceled, retry counter untouched); claimed ones finalize normally.
+func CancelQueued(app *application.Runtime, job coredb.VerificationJob) error {
+	ctx := context.Background()
+	exec, err := app.Engine.ActiveExecution(ctx, jobs.WorkflowVerification, job.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	exec, err = app.Engine.Cancel(ctx, exec.ID)
+	if errors.Is(err, jobdb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if exec.State != jobdb.StateCanceled {
+		return nil
+	}
+	queued, err := tasklog.NewQueuedTask("verification", queuedWorkerID(job), false)
+	if err != nil {
+		return err
+	}
+	queued.CloseErr(jobs.ErrCanceled)
+	current, err := app.CoreDB.GetVerificationJob(job.ID)
+	if err != nil {
+		return err
+	}
+	current.History.LastRunUpid = queued.UPID()
+	current.History.LastRunStarttime = queued.Task.StartTime
+	current.History.LastRunEndtime = time.Now().Unix()
+	current.History.LastRunState = "operation canceled"
+	current.History.LastRunStatus = coredb.JobStatusCanceled
+	return app.CoreDB.UpdateVerificationJob(nil, current)
+}


### PR DESCRIPTION
## Summary
- A job submitted while all engine concurrency slots are busy used to sit as an invisible pending jobdb row: no task log, no LastRunUpid, no stop button until a slot freed.
- Submit sites now mint the queued placeholder task immediately (backup/restore/verification/mtf, manual + scheduled + retry paths), so slot-waiting jobs show as QUEUED with a log and are stoppable from the moment they are accepted.
- The workflow's NewQueuedTask attaches to the minted task by (workerType, workerID) key (existing reuse), so takeovers, engine retries, and crash recovery behave exactly as before.
- Stop during the wait: CancelQueued cancels the pending execution, closes the task as canceled ("operation canceled" -> JobStatusCanceled, retry counter untouched), and writes job history; claimed executions still finalize through the workflow. Native PBS task-stop on the queued task also routes through the same path via an OnAbort hook.
- tasklog.UseTaskDir exported for cross-package task-dir redirection in tests; integration test covers mint -> history UPID -> cancel -> canceled status with RetryCount 0.